### PR TITLE
1. fix a memory leak bug. 2.small refine.

### DIFF
--- a/ijkmedia/ijkplayer/ff_ffplay.c
+++ b/ijkmedia/ijkplayer/ff_ffplay.c
@@ -3059,7 +3059,7 @@ void ffp_destroy(FFPlayer *ffp)
     if (!ffp)
         return;
 
-    if (ffp && ffp->is) {
+    if (ffp->is) {
         av_log(NULL, AV_LOG_WARNING, "ffp_destroy_ffplayer: force stream_close()");
         stream_close(ffp->is);
         ffp->is = NULL;
@@ -3069,11 +3069,11 @@ void ffp_destroy(FFPlayer *ffp)
     SDL_AoutFreeP(&ffp->aout);
     ffpipenode_free_p(&ffp->node_vdec);
     ffpipeline_free_p(&ffp->pipeline);
+    ijkmeta_destroy_p(&ffp->meta);
     ffp_reset_internal(ffp);
 
     msg_queue_destroy(&ffp->msg_queue);
 
-    ijkmeta_destroy_p(&ffp->meta);
 
     av_free(ffp);
 }

--- a/ijkmedia/ijkplayer/ijkmeta.c
+++ b/ijkmedia/ijkplayer/ijkmeta.c
@@ -40,7 +40,7 @@ IjkMediaMeta *ijkmeta_create()
 {
     IjkMediaMeta *meta = (IjkMediaMeta *)calloc(1, sizeof(IjkMediaMeta));
     if (!meta)
-        goto fail;
+        return NULL;
 
     meta->mutex = SDL_CreateMutex();
     if (!meta->mutex)


### PR DESCRIPTION
    We should do ffp->meta == NULL  in ffp_reset_internal() after free the memory ffp->meta point to,
otherwise the memory will leak.