### PR TITLE
enable arm64 for compile param ‘all’

### DIFF
--- a/android/compile-ijk.sh
+++ b/android/compile-ijk.sh
@@ -23,7 +23,7 @@ fi
 
 REQUEST_TARGET=$1
 REQUEST_SUB_CMD=$2
-ALL_ABI="armv5 armv7a x86"
+ALL_ABI="armv5 armv7a x86 arm64"
 
 do_sub_cmd () {
     SUB_CMD=$1

--- a/android/contrib/compile-ffmpeg.sh
+++ b/android/contrib/compile-ffmpeg.sh
@@ -68,7 +68,7 @@ case "$FF_TARGET" in
     ;;
     all)
         echo_archs
-        for ARCH in $FF_ACT_ARCHS
+        for ARCH in $FF_ALL_ARCHS
         do
             sh tools/do-compile-ffmpeg.sh $ARCH
         done

--- a/android/ijkplayer/player-arm64/build.gradle
+++ b/android/ijkplayer/player-arm64/build.gradle
@@ -8,7 +8,7 @@ android {
     buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion 9
         targetSdkVersion 22
     }
     buildTypes {

--- a/android/ijkplayer/sample/build.gradle
+++ b/android/ijkplayer/sample/build.gradle
@@ -30,5 +30,5 @@ dependencies {
     compile project(':player-x86')
     compile project(':player-armv5')
     // need API-21
-    // compile project(':player-arm64')
+     compile project(':player-arm64')
 }


### PR DESCRIPTION
hi @bbcallen 
Recently I've lots of crash reports on android 5.+, all these devices are ARM based devices with 64bits CPU. After studying the building scripts, I have succeed to solved the issue;

The compile-ijk and compile-ffmpeg scripts were kind of confusion, it declared the type of arm64, but the default "all" only compiling armv5/armv7a/x86.

I've just add the arm64 into the ALL_ABI.
(PS: tested on real device, nubia) 