### PR TITLE
1.修改了PacketQueue.duration的计算方式，使PacketQueue在丢帧的情况下，可以正确计算duration; 2.重构了ffp_check_buffering_l

### DIFF
--- a/ijkmedia/ijkplayer/ff_ffplay.c
+++ b/ijkmedia/ijkplayer/ff_ffplay.c
@@ -3680,10 +3680,10 @@ void ffp_check_buffering_l(FFPlayer *ffp)
     int buf_size_percent      = -1;
     int buf_time_percent      = -1;
     int hwm_in_bytes          = ffp->high_water_mark_in_bytes;
-    int need_start_buffering  = 0;
     int audio_time_base_valid = 0;
     int video_time_base_valid = 0;
     int64_t buf_time_position = -1;
+    static int need_continue_buffering  = 0;
 
     if(is->audio_st)
         audio_time_base_valid = is->audio_st->time_base.den > 0 && is->audio_st->time_base.num > 0;
@@ -3754,20 +3754,17 @@ void ffp_check_buffering_l(FFPlayer *ffp)
     }
 
     int buf_percent = -1;
-    if (buf_time_percent >= 0) {
-        // alwas depend on cache duration if valid
-        if (buf_time_percent >= 100)
-            need_start_buffering = 1;
-        buf_percent = buf_time_percent;
-    } else {
-        if (buf_size_percent >= 100)
-            need_start_buffering = 1;
-        buf_percent = buf_size_percent;
-    }
-
     if (buf_time_percent >= 0 && buf_size_percent >= 0) {
         buf_percent = FFMIN(buf_time_percent, buf_size_percent);
     }
+    else if (buf_time_percent >= 0) {
+        // alwas depend on cache duration if valid
+        buf_percent = buf_time_percent;
+    } else {
+        buf_percent = buf_size_percent;
+    }
+    need_continue_buffering = (buf_percent < 100);
+    
     if (buf_percent) {
 #ifdef FFP_SHOW_BUF_POS
         av_log(ffp, AV_LOG_DEBUG, "buf pos=%"PRId64", %%%d\n", buf_time_position, buf_percent);
@@ -3775,22 +3772,21 @@ void ffp_check_buffering_l(FFPlayer *ffp)
         ffp_notify_msg3(ffp, FFP_MSG_BUFFERING_UPDATE, (int)buf_time_position, buf_percent);
     }
 
-    if (need_start_buffering) {
+    if (need_continue_buffering) {
         if (hwm_in_ms < ffp->next_high_water_mark_in_ms) {
             hwm_in_ms = ffp->next_high_water_mark_in_ms;
         } else {
             hwm_in_ms *= 2;
         }
-
-        if (hwm_in_ms > ffp->max_high_water_mark_in_ms)
-            hwm_in_ms = ffp->max_high_water_mark_in_ms;
-
-        ffp->current_high_water_mark_in_ms = hwm_in_ms;
-
+        
+        ffp->current_high_water_mark_in_ms = FFMIN(hwm_in_ms, ffp->max_high_water_mark_in_ms);
+    }
+    else{
         if (is->buffer_indicator_queue && is->buffer_indicator_queue->nb_packets > 0) {
             if (   (is->audioq.nb_packets > MIN_MIN_FRAMES || is->audio_stream < 0 || is->audioq.abort_request)
                 && (is->videoq.nb_packets > MIN_MIN_FRAMES || is->video_stream < 0 || is->videoq.abort_request)) {
                 ffp_toggle_buffering(ffp, 0);
+                ffp->current_high_water_mark_in_ms = ffp->start_high_water_mark_in_ms;
             }
         }
     }

--- a/ijkmedia/ijkplayer/ff_ffplay.c
+++ b/ijkmedia/ijkplayer/ff_ffplay.c
@@ -278,8 +278,7 @@ static int packet_queue_put_private(PacketQueue *q, AVPacket *pkt)
     q->last_pkt = pkt1;
     q->nb_packets++;
     q->size += pkt1->pkt.size + sizeof(*pkt1);
-    if (pkt1->pkt.duration > 0)
-        q->duration += pkt1->pkt.duration;
+    q->duration = (q->last_pkt->pkt.duration + q->last_pkt->pkt.pts - q->first_pkt->pkt.pts);
     /* XXX: should duplicate packet data in DV case */
     SDL_CondSignal(q->cond);
     return 0;
@@ -402,8 +401,7 @@ static int packet_queue_get(PacketQueue *q, AVPacket *pkt, int block, int *seria
                 q->last_pkt = NULL;
             q->nb_packets--;
             q->size -= pkt1->pkt.size + sizeof(*pkt1);
-            if (pkt1->pkt.duration > 0)
-                q->duration -= pkt1->pkt.duration;
+            q->duration = q->last_pkt ? (q->last_pkt->pkt.duration + q->last_pkt->pkt.pts - q->first_pkt->pkt.pts) : 0;
             *pkt = pkt1->pkt;
             if (serial)
                 *serial = pkt1->serial;


### PR DESCRIPTION
播放器被用于流媒体(如RTMP)播放时，可能由于网络错误，导致某段时间内的音视频包丢失，这在播放过程中表现为：video会delay最多is->max_frame_duration时间，audio会播放静音，即PacketQueue的duration不再等于各AVPacket的duration之和，而是(q->last_pkt->pkt.duration + q->last_pkt->pkt.pts - q->first_pkt->pkt.pts)。为了解决这个问题，我做了这次(fa48d5e)的修改。