### PR TITLE
android/mediacodec: add function to support H265/HEVC.

### DIFF
--- a/ijkmedia/ijkplayer/android/pipeline/hevc_nal.h
+++ b/ijkmedia/ijkplayer/android/pipeline/hevc_nal.h
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2015 Chodison Chen <c_soft_dev@163.com>
+ *
+ * This file is part of ijkPlayer.
+ *
+ * ijkPlayer is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * ijkPlayer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with ijkPlayer; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include <limits.h>
+#include "libavcodec/avcodec.h"
+#include "ijksdl/ijksdl_log.h"
+
+/* Inspired by libavcodec/hevc.c */
+int convert_hevc_nal_units(const uint8_t *p_buf,uint32_t i_buf_size,
+                           uint8_t *p_out_buf,uint32_t i_out_buf_size,
+                           uint32_t *p_sps_pps_size,uint32_t *p_nal_size)
+{
+    int i, num_arrays;
+    const uint8_t *p_end = p_buf + i_buf_size;
+    uint32_t i_sps_pps_size = 0;
+
+    if( i_buf_size <= 3 || ( !p_buf[0] && !p_buf[1] && p_buf[2] <= 1 ) )
+        return -1;
+
+    if( p_end - p_buf < 23 )
+    {
+        ALOGE( "Input Metadata too small" );
+        return -1;
+    }
+
+    p_buf += 21;
+
+    if( p_nal_size )
+        *p_nal_size = (*p_buf & 0x03) + 1;
+    p_buf++;
+
+    num_arrays = *p_buf++;
+
+    for( i = 0; i < num_arrays; i++ )
+    {
+        int type, cnt, j;
+
+        if( p_end - p_buf < 3 )
+        {
+            ALOGE( "Input Metadata too small" );
+            return -1;
+        }
+        type = *(p_buf++) & 0x3f;
+        (void)(type);
+
+        cnt = p_buf[0] << 8 | p_buf[1];
+        p_buf += 2;
+
+        for( j = 0; j < cnt; j++ )
+        {
+            int i_nal_size;
+
+            if( p_end - p_buf < 2 )
+            {
+                ALOGE( "Input Metadata too small" );
+                return -1;
+            }
+
+            i_nal_size = p_buf[0] << 8 | p_buf[1];
+            p_buf += 2;
+
+            if( i_nal_size < 0 || p_end - p_buf < i_nal_size )
+            {
+                ALOGE( "NAL unit size does not match Input Metadata size" );
+                return -1;
+            }
+
+            if( i_sps_pps_size + 4 + i_nal_size > i_out_buf_size )
+            {
+                ALOGE( "Output buffer too small" );
+                return -1;
+            }
+
+            p_out_buf[i_sps_pps_size++] = 0;
+            p_out_buf[i_sps_pps_size++] = 0;
+            p_out_buf[i_sps_pps_size++] = 0;
+            p_out_buf[i_sps_pps_size++] = 1;
+
+            memcpy(p_out_buf + i_sps_pps_size, p_buf, i_nal_size);
+            p_buf += i_nal_size;
+
+            i_sps_pps_size += i_nal_size;
+        }
+    }
+
+    *p_sps_pps_size = i_sps_pps_size;
+
+    return 0;
+}

--- a/ijkmedia/ijksdl/android/android_audiotrack.c
+++ b/ijkmedia/ijksdl/android/android_audiotrack.c
@@ -579,7 +579,7 @@ int SDL_Android_AudioTrack_reserve_float_buffer(JNIEnv *env, SDL_Android_AudioTr
     int capacity = IJKMAX(size_in_float, ((atrack->min_buffer_size + sizeof(jfloat) - 1) / sizeof(jfloat)));
     jbyteArray float_buffer = (*env)->NewFloatArray(env, capacity);
     if (!float_buffer || (*env)->ExceptionCheck(env)) {
-        ALOGE("%s: NewByteArray: Exception:\n", __func__);
+        ALOGE("%s: NewFloatArray: Exception:\n", __func__);
         if ((*env)->ExceptionCheck(env)) {
             (*env)->ExceptionDescribe(env);
             (*env)->ExceptionClear(env);
@@ -606,7 +606,7 @@ int SDL_Android_AudioTrack_write_float(JNIEnv *env, SDL_Android_AudioTrack *atra
 
     (*env)->SetFloatArrayRegion(env, atrack->float_buffer, 0, (int)size_in_float, (jfloat*) data);
     if ((*env)->ExceptionCheck(env)) {
-        ALOGE("%s: SetByteArrayRegion: Exception:\n", __func__);
+        ALOGE("%s: SetFloatArrayRegion: Exception:\n", __func__);
         if ((*env)->ExceptionCheck(env)) {
             (*env)->ExceptionDescribe(env);
             (*env)->ExceptionClear(env);
@@ -617,7 +617,7 @@ int SDL_Android_AudioTrack_write_float(JNIEnv *env, SDL_Android_AudioTrack *atra
     int retval = (*env)->CallIntMethod(env, atrack->thiz, g_clazz.write_float,
         atrack->float_buffer, 0, (int)size_in_float, (int)WRITE_BLOCKING);
     if ((*env)->ExceptionCheck(env)) {
-        ALOGE("%s: write_byte: Exception:\n", __func__);
+        ALOGE("%s: write_float: Exception:\n", __func__);
         if ((*env)->ExceptionCheck(env)) {
             (*env)->ExceptionDescribe(env);
             (*env)->ExceptionClear(env);

--- a/ijkmedia/ijksdl/android/ijksdl_vout_overlay_android_mediacodec.c
+++ b/ijkmedia/ijksdl/android/ijksdl_vout_overlay_android_mediacodec.c
@@ -135,7 +135,7 @@ static int func_fill_frame(SDL_VoutOverlay *overlay, const AVFrame *frame)
 
 SDL_VoutOverlay *SDL_VoutAMediaCodec_CreateOverlay(int width, int height, Uint32 format, SDL_Vout *vout)
 {
-    SDLTRACE("SDL_VoutFFmpeg_CreateOverlay(w=%d, h=%d, fmt=%.4s(0x%x, vout=%p)\n",
+    SDLTRACE("SDL_VoutAMediaCodec_CreateOverlay(w=%d, h=%d, fmt=%.4s(0x%x, vout=%p)\n",
         width, height, (const char*) &format, format, vout);
     SDL_VoutOverlay *overlay = SDL_VoutOverlay_CreateInternal(sizeof(SDL_VoutOverlay_Opaque));
     if (!overlay) {


### PR DESCRIPTION
bbcallen, It is OK to decoder H265 file for android mediacodec.