### PR TITLE
ios/player: fix IJKAVMoviePlayerController play in background or lock…

### DIFF
--- a/ios/IJKMediaPlayer/IJKMediaPlayer/IJKAVMoviePlayerController.m
+++ b/ios/IJKMediaPlayer/IJKMediaPlayer/IJKAVMoviePlayerController.m
@@ -740,7 +740,7 @@ static IJKAVMoviePlayerController* instance;
                  postNotificationName:IJKMPMediaPlaybackIsPreparedToPlayDidChangeNotification
                  object:self];
 
-                if (_shouldAutoplay)
+                if (_shouldAutoplay && (!_pauseInBackground || [UIApplication sharedApplication].applicationState == UIApplicationStateActive))
                     [_player play];
             }
                 break;


### PR DESCRIPTION
Fix IJKAVMoviePlayerController play in background or locked screen when it set pauseInBackground=YES.