### PR TITLE
fix parallel make on osx

### DIFF
--- a/android/compile-ijk.sh
+++ b/android/compile-ijk.sh
@@ -26,12 +26,13 @@ REQUEST_SUB_CMD=$2
 ACT_ABI_32="armv5 armv7a x86"
 ACT_ABI_64="armv5 armv7a arm64 x86 x86_64"
 ACT_ABI_ALL=$ALL_ABI_64
+UNAME_S=$(uname -s)
 
 FF_MAKEFLAGS=
 if which nproc >/dev/null
 then
     FF_MAKEFLAGS=-j`nproc`
-elif [ "$UNAMES" = "Darwin" ] && which sysctl >/dev/null
+elif [ "$UNAME_S" = "Darwin" ] && which sysctl >/dev/null
 then
     FF_MAKEFLAGS=-j`sysctl -n machdep.cpu.thread_count`
 fi

--- a/android/contrib/tools/do-compile-ffmpeg.sh
+++ b/android/contrib/tools/do-compile-ffmpeg.sh
@@ -217,7 +217,7 @@ FF_MAKEFLAGS=
 if which nproc >/dev/null
 then
     FF_MAKEFLAGS=-j`nproc`
-elif [ "$UNAMES" = "Darwin" ] && which sysctl >/dev/null
+elif [ "$UNAME_S" = "Darwin" ] && which sysctl >/dev/null
 then
     FF_MAKEFLAGS=-j`sysctl -n machdep.cpu.thread_count`
 fi

--- a/android/contrib/tools/do-compile-openssl.sh
+++ b/android/contrib/tools/do-compile-openssl.sh
@@ -117,9 +117,9 @@ mkdir -p $FF_SYSROOT
 echo "\n--------------------"
 echo "[*] make NDK standalone toolchain"
 echo "--------------------"
-UNAMES=$(uname -s)
+UNAME_S=$(uname -s)
 FF_MAKE_TOOLCHAIN_FLAGS="--install-dir=$FF_TOOLCHAIN_PATH"
-if [ "$UNAMES" = "Darwin" ]; then
+if [ "$UNAME_S" = "Darwin" ]; then
     echo "build on darwin-x86_64"
     FF_MAKE_TOOLCHAIN_FLAGS="$FF_MAKE_TOOLCHAIN_FLAGS --system=darwin-x86_64"
     FF_MAKE_FLAG=-j`sysctl -n machdep.cpu.thread_count`
@@ -129,7 +129,7 @@ FF_MAKEFLAGS=
 if which nproc >/dev/null
 then
     FF_MAKEFLAGS=-j`nproc`
-elif [ "$UNAMES" = "Darwin" ] && which sysctl >/dev/null
+elif [ "$UNAME_S" = "Darwin" ] && which sysctl >/dev/null
 then
     FF_MAKEFLAGS=-j`sysctl -n machdep.cpu.thread_count`
 fi


### PR DESCRIPTION
Fix problem may cause make cannot be parallel:
- Undefined variable $UNAMES (should be $UNAME_S)
https://github.com/Bilibili/ijkplayer/blob/5e6bb1ab22a4e5117ded240eb7f9aa5860265e59/android/contrib/tools/do-compile-ffmpeg.sh#L220
- Undefined variable $UNAMES (missing declare of $UNAMES)
https://github.com/Bilibili/ijkplayer/blob/5e6bb1ab22a4e5117ded240eb7f9aa5860265e59/android/compile-ijk.sh#L34

For naming consistent reasons, I renamed all $UNAMES to $UNAME_S.