### PR TITLE
Added player option, no-time-adjust

### DIFF
--- a/ijkmedia/ijkplayer/ff_ffplay.c
+++ b/ijkmedia/ijkplayer/ff_ffplay.c
@@ -3538,6 +3538,14 @@ long ffp_get_current_position_l(FFPlayer *ffp)
         pos = pos_clock * 1000;
     }
 
+    // If using REAL time and not ajusted, then return the real pos as calculated from the stream
+    // the use case for this is primarily when using a custom non-seekable data source that starts
+    // with a buffer that is NOT the start of the stream.  We want the get_current_position to
+    // return the time in the stream, and not the player's internal clock.
+    if (ffp->no_time_adjust) {
+        return pos;
+    }
+
     if (pos < 0 || pos < start_diff)
         return 0;
 

--- a/ijkmedia/ijkplayer/ff_ffplay_def.h
+++ b/ijkmedia/ijkplayer/ff_ffplay_def.h
@@ -612,6 +612,8 @@ typedef struct FFPlayer {
 
     char *iformat_name;
 
+    int no_time_adjust;
+
     struct IjkMediaMeta *meta;
 
     SDL_SpeedSampler vfps_sampler;
@@ -720,6 +722,8 @@ inline static void ffp_reset_internal(FFPlayer *ffp)
     ffp->opensles                       = 0; // option
 
     ffp->iformat_name                   = NULL; // option
+
+    ffp->no_time_adjust                 = 0; // option
 
     ijkmeta_reset(ffp->meta);
 

--- a/ijkmedia/ijkplayer/ff_ffplay_options.h
+++ b/ijkmedia/ijkplayer/ff_ffplay_options.h
@@ -128,8 +128,11 @@ static const AVOption ffp_context_options[] = {
         OPTION_OFFSET(sync_av_start),       OPTION_INT(1, 0, 1) },
     { "iformat",                            "force format",
         OPTION_OFFSET(iformat_name),        OPTION_STR(NULL) },
+    { "no-time-adjust",                     "return player's real time from the media stream instead of the adjusted time",
+      OPTION_OFFSET(no_time_adjust),   OPTION_INT(0, 0, 1) },
 
-    // iOS only options
+
+        // iOS only options
     { "videotoolbox",                       "VideoToolbox: enable",
         OPTION_OFFSET(videotoolbox),        OPTION_INT(0, 0, 1) },
     { "videotoolbox-max-frame-width",       "VideoToolbox: max width of output frame",


### PR DESCRIPTION
no-time-adjust can be used to prevent the player from returning an adjusted time, but rather, return the real time from the stream.

This is in response to the following enhancement request.
https://github.com/Bilibili/ijkplayer/issues/799

