### PR TITLE
Add mpeg2 hardware decoding support via Android's MediaCodec api.

### DIFF
--- a/ijkmedia/ijkplayer/android/pipeline/ffpipeline_android.c
+++ b/ijkmedia/ijkplayer/android/pipeline/ffpipeline_android.c
@@ -69,7 +69,7 @@ static IJKFF_Pipenode *func_open_video_decoder(IJKFF_Pipeline *pipeline, FFPlaye
     IJKFF_Pipeline_Opaque *opaque = pipeline->opaque;
     IJKFF_Pipenode        *node = NULL;
 
-    if (ffp->mediacodec_all_videos || ffp->mediacodec_avc || ffp->mediacodec_hevc)
+    if (ffp->mediacodec_all_videos || ffp->mediacodec_avc || ffp->mediacodec_hevc || ffp->mediacodec_mpeg2)
         node = ffpipenode_create_video_decoder_from_android_mediacodec(ffp, pipeline, opaque->weak_vout);
     if (!node) {
         node = ffpipenode_create_video_decoder_from_ffplay(ffp);

--- a/ijkmedia/ijkplayer/android/pipeline/ffpipenode_android_mediacodec_vdec.c
+++ b/ijkmedia/ijkplayer/android/pipeline/ffpipenode_android_mediacodec_vdec.c
@@ -1007,6 +1007,16 @@ IJKFF_Pipenode *ffpipenode_create_video_decoder_from_android_mediacodec(FFPlayer
         opaque->mcc.profile = opaque->avctx->profile;
         opaque->mcc.level   = opaque->avctx->level;
         break;
+    case AV_CODEC_ID_MPEG2VIDEO:
+        if (!ffp->mediacodec_mpeg2 && !ffp->mediacodec_all_videos) {
+            ALOGE("%s: MediaCodec/MPEG2VIDEO is disabled. codec_id:%d \n", __func__, opaque->avctx->codec_id);
+            goto fail;
+        }
+        strcpy(opaque->mcc.mime_type, SDL_AMIME_VIDEO_MPEG2VIDEO);
+        opaque->mcc.profile = opaque->avctx->profile;
+        opaque->mcc.level   = opaque->avctx->level;
+        break;
+
     default:
         ALOGE("%s:create: not H264 or H265/HEVC, codec_id:%d \n", __func__, opaque->avctx->codec_id);
         goto fail;

--- a/ijkmedia/ijkplayer/ff_ffplay_def.h
+++ b/ijkmedia/ijkplayer/ff_ffplay_def.h
@@ -609,6 +609,7 @@ typedef struct FFPlayer {
     int mediacodec_all_videos;
     int mediacodec_avc;
     int mediacodec_hevc;
+    int mediacodec_mpeg2;
     int mediacodec_auto_rotate;
 
     int opensles;
@@ -720,6 +721,7 @@ inline static void ffp_reset_internal(FFPlayer *ffp)
     ffp->mediacodec_all_videos          = 0; // option
     ffp->mediacodec_avc                 = 0; // option
     ffp->mediacodec_hevc                = 0; // option
+    ffp->mediacodec_mpeg2               = 0; // option
     ffp->mediacodec_auto_rotate         = 0; // option
 
     ffp->opensles                       = 0; // option

--- a/ijkmedia/ijkplayer/ff_ffplay_options.h
+++ b/ijkmedia/ijkplayer/ff_ffplay_options.h
@@ -153,7 +153,8 @@ static const AVOption ffp_context_options[] = {
         OPTION_OFFSET(mediacodec_avc),          OPTION_INT(0, 0, 1) },
     { "mediacodec-hevc",                        "MediaCodec: enable HEVC",
         OPTION_OFFSET(mediacodec_hevc),         OPTION_INT(0, 0, 1) },
-
+    { "mediacodec-mpeg2",                       "MediaCodec: enable MPEG2VIDEO",
+        OPTION_OFFSET(mediacodec_mpeg2),         OPTION_INT(0, 0, 1) },
     { "opensles",                           "OpenSL ES: enable",
         OPTION_OFFSET(opensles),            OPTION_INT(0, 0, 1) },
     

--- a/ijkmedia/ijksdl/android/ijksdl_codec_android_mediadef.h
+++ b/ijkmedia/ijksdl/android/ijksdl_codec_android_mediadef.h
@@ -52,6 +52,7 @@ typedef enum sdl_amedia_status_t {
 #define SDL_AMIME_VIDEO_VP9         "video/x-vnd.on2.vp9"   //- VP9 video (i.e. video in .webm)
 #define SDL_AMIME_VIDEO_AVC         "video/avc"             //- H.264/AVC video
 #define SDL_AMIME_VIDEO_HEVC        "video/hevc"            //- H.265/HEVC video
+#define SDL_AMIME_VIDEO_MPEG2VIDEO  "video/mpeg2"           //- H.265/HEVC video
 #define SDL_AMIME_VIDEO_MPEG4       "video/mp4v-es"         //- MPEG4 video
 #define SDL_AMIME_VIDEO_H264        "video/3gpp"            //- H.263 video
 #define SDL_AMIME_AUDIO_AMR_NB      "audio/3gpp"            //- AMR narrowband audio


### PR DESCRIPTION
I'm not sure if there is more that I needed to do, but, I've tested this on an NVidia Shield TV and it does use the mpeg2 hardware decoder.  (I can tell based on logging, and, the same video played when the mpeg2 decoder is disabled is very pixalated using the ffplay decoder vs when I enable my mpeg2 option, then video is extremely clear)