### PR TITLE
FFMpeg: Disable ASM on x86 builds

### DIFF
--- a/android/contrib/tools/do-compile-ffmpeg.sh
+++ b/android/contrib/tools/do-compile-ffmpeg.sh
@@ -290,9 +290,13 @@ FF_CFG_FLAGS="$FF_CFG_FLAGS --target-os=linux"
 FF_CFG_FLAGS="$FF_CFG_FLAGS --enable-pic"
 # FF_CFG_FLAGS="$FF_CFG_FLAGS --disable-symver"
 
-# Optimization options (experts only):
-FF_CFG_FLAGS="$FF_CFG_FLAGS --enable-asm"
-FF_CFG_FLAGS="$FF_CFG_FLAGS --enable-inline-asm"
+if [ "$FF_ARCH" = "x86" ]; then
+    FF_CFG_FLAGS="$FF_CFG_FLAGS --disable-asm"
+else 
+    # Optimization options (experts only):
+    FF_CFG_FLAGS="$FF_CFG_FLAGS --enable-asm"
+    FF_CFG_FLAGS="$FF_CFG_FLAGS --enable-inline-asm"
+fi
 
 #--------------------
 echo ""


### PR DESCRIPTION
This "fix" text relocations on targetSDK 23.

* Tested on emulator (sdk_google_phone_x86-userdebug 6.0 MASTER 2524533 test-keys) 

Signed-off-by: Victor Roque <victor.rooque@gmail.com>