### PR TITLE
fix wrong position after resume from paused

### DIFF
--- a/ijkmedia/ijksdl/android/ijksdl_aout_android_audiotrack.c
+++ b/ijkmedia/ijksdl/android/ijksdl_aout_android_audiotrack.c
@@ -90,7 +90,7 @@ static int aout_thread_n(JNIEnv *env, SDL_Aout *aout)
         if (!opaque->abort_request && opaque->pause_on) {
             SDL_Android_AudioTrack_pause(env, atrack);
             while (!opaque->abort_request && opaque->pause_on) {
-                audio_cblk(userdata, buffer, copy_size);
+                audio_cblk(userdata, buffer, 0);
                 SDL_CondWaitTimeout(opaque->wakeup_cond, opaque->wakeup_mutex, 50);
             }
             if (!opaque->abort_request && !opaque->pause_on)

--- a/ijkmedia/ijksdl/android/ijksdl_aout_android_audiotrack.c
+++ b/ijkmedia/ijksdl/android/ijksdl_aout_android_audiotrack.c
@@ -90,7 +90,8 @@ static int aout_thread_n(JNIEnv *env, SDL_Aout *aout)
         if (!opaque->abort_request && opaque->pause_on) {
             SDL_Android_AudioTrack_pause(env, atrack);
             while (!opaque->abort_request && opaque->pause_on) {
-                SDL_CondWaitTimeout(opaque->wakeup_cond, opaque->wakeup_mutex, 1000);
+                audio_cblk(userdata, buffer, copy_size);
+                SDL_CondWaitTimeout(opaque->wakeup_cond, opaque->wakeup_mutex, 50);
             }
             if (!opaque->abort_request && !opaque->pause_on)
                 SDL_Android_AudioTrack_play(env, atrack);


### PR DESCRIPTION
'c->last_updated' in ff_ffplay.c dosen't update after stream paused, so the current play time returned by get_master_clock elapsed as in play state.The result is the first ffp_get_current_position_l call right after resume maybe return a wrong value and returns correct value from next call.
This can be fixed by make periodically call of audio_cblk and decrease the wait timeout like ffplay.c dose.