### PR TITLE
Video toolbox only support avcC, some h264 stream is not strict avcC. Better compatibility

### DIFF
--- a/ios/IJKMediaPlayer/IJKMediaPlayer/ijkmedia/ijkplayer/ios/pipeline/IJKVideoToolBox.m
+++ b/ios/IJKMediaPlayer/IJKMediaPlayer/ijkmedia/ijkplayer/ios/pipeline/IJKVideoToolBox.m
@@ -39,6 +39,9 @@
 #define IJK_VTB_FCC_ESD    SDL_FOURCC('s', 'd', 's', 'e')
 #define IJK_VTB_FCC_AVC1   SDL_FOURCC('1', 'c', 'v', 'a')
 
+static const uint8_t kStartCode[4] = {0, 0, 0, 1};
+static const size_t kStartCodeSize = 4;
+
 
 static const char *vtb_get_error_string(OSStatus status) {
     switch (status) {
@@ -184,11 +187,57 @@ inline static void sample_info_recycle(VideoToolBoxContext* context, sample_info
     SDL_UnlockMutex(context->sample_info_mutex);
 }
 
+static uint8_t *search_start_code(uint8_t *data, size_t size)
+{
+    if (size < kStartCodeSize) {
+        return NULL;
+    }
+    
+    for (int i = 0; i < size - kStartCodeSize; i++) {
+        if (memcmp(data + i, kStartCode, kStartCodeSize) == 0) {
+            return data + i;
+        }
+    }
+    
+    return NULL;
+}
+
+static void annexB_to_AVC(uint8_t *in_buff, size_t in_size, uint8_t **out_buff, size_t *out_size)
+{
+    size_t size = 0;
+    uint8_t *p_start_code = search_start_code(in_buff, in_size);
+    if (p_start_code == NULL) {
+        /* no start code, AVC */
+        *out_buff = in_buff;
+        *out_size = in_size;
+    }
+    
+    while (p_start_code != NULL) {
+        size_t remain_size = in_size - (p_start_code - in_buff) - kStartCodeSize;
+        uint8_t *p_next_code = search_start_code(p_start_code + kStartCodeSize, remain_size);
+        
+        size_t move_size = remain_size;
+        if (p_next_code != NULL) {
+            move_size = p_next_code - p_start_code - kStartCodeSize;
+        }
+        memmove(in_buff + size, p_start_code + kStartCodeSize, move_size);
+        
+        size += move_size;
+        p_start_code = p_next_code;
+    }
+    
+    *out_buff = in_buff;
+    *out_size = size;
+}
+
 static CMSampleBufferRef CreateSampleBufferFrom(CMFormatDescriptionRef fmt_desc, void *demux_buff, size_t demux_size)
 {
     OSStatus status;
     CMBlockBufferRef newBBufOut = NULL;
     CMSampleBufferRef sBufOut = NULL;
+    
+    /* VideoToolbox only support avcC */
+    annexB_to_AVC((uint8_t *)demux_buff, demux_size, (uint8_t **)&demux_buff, &demux_size);
 
     status = CMBlockBufferCreateWithMemoryBlock(
                                                 NULL,
@@ -224,9 +273,6 @@ static CMSampleBufferRef CreateSampleBufferFrom(CMFormatDescriptionRef fmt_desc,
         return NULL;
     }
 }
-
-
-
 
 static bool GetVTBPicture(VideoToolBoxContext* context, AVFrame* pVTBPicture)
 {
@@ -756,29 +802,38 @@ static void dict_set_i32(CFMutableDictionaryRef dict, CFStringRef key,
 static CMFormatDescriptionRef CreateFormatDescriptionFromCodecData(Uint32 format_id, int width, int height, const uint8_t *extradata, int extradata_size, uint32_t atom)
 {
     CMFormatDescriptionRef fmt_desc = NULL;
-    OSStatus status;
-
-    CFMutableDictionaryRef par = CFDictionaryCreateMutable(NULL, 0, &kCFTypeDictionaryKeyCallBacks,&kCFTypeDictionaryValueCallBacks);
-    CFMutableDictionaryRef atoms = CFDictionaryCreateMutable(NULL, 0, &kCFTypeDictionaryKeyCallBacks,&kCFTypeDictionaryValueCallBacks);
-    CFMutableDictionaryRef extensions = CFDictionaryCreateMutable(NULL, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
-
-    /* CVPixelAspectRatio dict */
-    dict_set_i32(par, CFSTR ("HorizontalSpacing"), 0);
-    dict_set_i32(par, CFSTR ("VerticalSpacing"), 0);
-    /* SampleDescriptionExtensionAtoms dict */
-    dict_set_data(atoms, CFSTR ("avcC"), (uint8_t *)extradata, extradata_size);
-
-      /* Extensions dict */
-    dict_set_string(extensions, CFSTR ("CVImageBufferChromaLocationBottomField"), "left");
-    dict_set_string(extensions, CFSTR ("CVImageBufferChromaLocationTopField"), "left");
-    dict_set_boolean(extensions, CFSTR("FullRangeVideo"), FALSE);
-    dict_set_object(extensions, CFSTR ("CVPixelAspectRatio"), (CFTypeRef *) par);
-    dict_set_object(extensions, CFSTR ("SampleDescriptionExtensionAtoms"), (CFTypeRef *) atoms);
-    status = CMVideoFormatDescriptionCreate(NULL, format_id, width, height, extensions, &fmt_desc);
-
-    CFRelease(extensions);
-    CFRelease(atoms);
-    CFRelease(par);
+    
+    const uint8_t *p = extradata + 4;  /* skip 4 bytes */
+    
+    /* retrieve length coded size */
+    size_t length_size = (*p++ & 0x3) + 1;
+    if (length_size == 3)
+        return NULL;
+    
+    
+    /* retrieve sps and pps unit(s) */
+    size_t unit_nb = *p++ & 0x1f; /* number of sps unit(s) */
+    if (!unit_nb) {
+        return NULL;
+    }
+    
+    size_t sps_size = AV_RB16(p);
+    const uint8_t *sps = p + 2;
+    
+    p += sps_size + 2;
+    size_t pps_size = AV_RB16(p);
+    const uint8_t *pps = p + 2;
+    
+    
+    const uint8_t* const parameterSetPointers[2] = { sps, pps };
+    const size_t parameterSetSizes[2] = { sps_size, pps_size };
+    OSStatus status = CMVideoFormatDescriptionCreateFromH264ParameterSets(kCFAllocatorDefault,
+                                                                          2, //param count
+                                                                          parameterSetPointers,
+                                                                          parameterSetSizes,
+                                                                          4, //nal start code size
+                                                                          &fmt_desc);
+    
 
     if (status == 0)
         return fmt_desc;

--- a/ios/IJKMediaPlayer/IJKMediaPlayer/ijkmedia/ijkplayer/ios/pipeline/h264_sps_parser.h
+++ b/ios/IJKMediaPlayer/IJKMediaPlayer/ijkmedia/ijkplayer/ios/pipeline/h264_sps_parser.h
@@ -37,6 +37,18 @@
 (((const uint8_t*)(x))[2] <<  8) |        \
 ((const uint8_t*)(x))[3])
 
+char *
+AV_Encode32(char *output, char *outend, int nVal)
+{
+    if (output+4 > outend)
+        return NULL;
+    
+    output[3] = nVal & 0xff;
+    output[2] = nVal >> 8;
+    output[1] = nVal >> 16;
+    output[0] = nVal >> 24;
+    return output+4;
+}
 
 /* NAL unit types */
 enum {

--- a/ios/IJKMediaPlayer/IJKMediaPlayer/ijkmedia/ijkplayer/ios/pipeline/h264_sps_parser.h
+++ b/ios/IJKMediaPlayer/IJKMediaPlayer/ijkmedia/ijkplayer/ios/pipeline/h264_sps_parser.h
@@ -37,18 +37,6 @@
 (((const uint8_t*)(x))[2] <<  8) |        \
 ((const uint8_t*)(x))[3])
 
-char *
-AV_Encode32(char *output, char *outend, int nVal)
-{
-    if (output+4 > outend)
-        return NULL;
-    
-    output[3] = nVal & 0xff;
-    output[2] = nVal >> 8;
-    output[1] = nVal >> 16;
-    output[0] = nVal >> 24;
-    return output+4;
-}
 
 /* NAL unit types */
 enum {


### PR DESCRIPTION
由此也可发现，VideoToolbox编码输出为avcC格式，而且VideoToolbox也只支持avcC格式的H.264。如果从网络中得到Annex-B格式的H.264数据（一般称作H.264裸流或Elementary Stream），用CMVideoFormatDescriptionCreateFromH264ParameterSets创建视频格式描述更方便，同时解码时需要将Annex-B转换成avcC，这也是WWDC2014 513 "direct access to media encoding and decoding"中说VideoToolbox只支持MP4容器装载的H.264数据的原因，就我所知，当写入MP4时，Annex-B使用的起始码（Start Code）会被写成长度（Length）。这就是VideoToolBox硬解最容易出问题的点，

文／赖__82084788（简书作者）
原文链接：http://www.jianshu.com/p/9febe519732a
著作权归作者所有，转载请联系作者获得授权，并标注“简书作者”。