### PR TITLE
android/ffmpeg:fix compile err while use ndk 11c.

### DIFF
--- a/android/contrib/tools/do-detect-env.sh
+++ b/android/contrib/tools/do-detect-env.sh
@@ -68,7 +68,7 @@ case "$IJK_NDK_REL" in
         IJK_NDK_REL=$(grep -o '^Pkg\.Revision.*=[0-9]*.*' $ANDROID_NDK/source.properties 2>/dev/null | sed 's/[[:space:]]*//g' | cut -d "=" -f 2)
         echo "IJK_NDK_REL=$IJK_NDK_REL"
         case "$IJK_NDK_REL" in
-            11|12*)
+            11*|12*)
                 if test -d ${ANDROID_NDK}/toolchains/arm-linux-androideabi-4.9
                 then
                     echo "NDKr$IJK_NDK_REL detected"


### PR DESCRIPTION
I using the android ndk 11c as my ndk env. I got an error while execute
the "android/contrib/compile-ffmpeg.sh all", error message as:
You need the NDKr10e or later