### PR TITLE
add mpeg4 mediacodec support

### DIFF
--- a/ijkmedia/ijkplayer/android/pipeline/ffpipenode_android_mediacodec_vdec.c
+++ b/ijkmedia/ijkplayer/android/pipeline/ffpipenode_android_mediacodec_vdec.c
@@ -32,6 +32,7 @@
 #include "ijkplayer/ff_ffplay_debug.h"
 #include "h264_nal.h"
 #include "hevc_nal.h"
+#include "mpeg4_esds.h"
 #include "ffpipeline_android.h"
 
 #define AMC_USE_AVBITSTREAM_FILTER 0
@@ -227,6 +228,14 @@ static int recreate_format_l(JNIEnv *env, IJKFF_Pipenode *node)
             }
             free(convert_buffer);
 #endif
+        } else if (opaque->codecpar->codec_id == AV_CODEC_ID_MPEG4) {
+            size_t esds_dec_dscr_type_length = opaque->codecpar->extradata_size + 0x18;
+            size_t esds_es_dscr_type_length = esds_dec_dscr_type_length + 0x08;
+            size_t esds_size = esds_es_dscr_type_length + 0x05;
+            uint8_t *convert_buffer = (uint8_t *)calloc(1, esds_size);
+            restore_mpeg4_esds(opaque->codecpar, opaque->codecpar->extradata, opaque->codecpar->extradata_size, esds_es_dscr_type_length, esds_dec_dscr_type_length, convert_buffer);
+            SDL_AMediaFormat_setBuffer(opaque->input_aformat, "csd-0", convert_buffer, esds_size);
+            free(convert_buffer);
         } else {
             // Codec specific data
             // SDL_AMediaFormat_setBuffer(opaque->aformat, "csd-0", opaque->codecpar->extradata, opaque->codecpar->extradata_size);
@@ -1186,6 +1195,19 @@ IJKFF_Pipenode *ffpipenode_create_video_decoder_from_android_mediacodec(FFPlayer
         strcpy(opaque->mcc.mime_type, SDL_AMIME_VIDEO_MPEG2VIDEO);
         opaque->mcc.profile = opaque->codecpar->profile;
         opaque->mcc.level   = opaque->codecpar->level;
+        break;
+    case AV_CODEC_ID_MPEG4:
+        if (!ffp->mediacodec_mpeg4 && !ffp->mediacodec_all_videos) {
+            ALOGE("%s: MediaCodec/MPEG4 is disabled. codec_id:%d \n", __func__, opaque->codecpar->codec_id);
+            goto fail;
+        }
+        if ((opaque->codecpar->codec_tag & 0x0000FFFF) == 0x00005844) {
+            ALOGE("%s: divx is not supported \n", __func__);
+            goto fail;
+        }
+        strcpy(opaque->mcc.mime_type, SDL_AMIME_VIDEO_MPEG4);
+        opaque->mcc.profile = opaque->codecpar->profile >= 0 ? opaque->codecpar->profile : 0;
+        opaque->mcc.level   = opaque->codecpar->level >= 0 ? opaque->codecpar->level : 1;
         break;
 
     default:

--- a/ijkmedia/ijkplayer/android/pipeline/mpeg4_esds.h
+++ b/ijkmedia/ijkplayer/android/pipeline/mpeg4_esds.h
@@ -1,0 +1,64 @@
+/*
+ * hevc_nal.h
+ * 
+ * Copyright (c) 2015 yuazhen <zhengyuan10503@gmail.com>
+ *
+ * This file is part of ijkPlayer.
+ *
+ * ijkPlayer is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * ijkPlayer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with ijkPlayer; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include <limits.h>
+#include <stdint.h>
+#include "libavcodec/avcodec.h"
+
+static void restore_mpeg4_esds(AVCodecParameters *codecpar,
+                                 uint8_t *p_buf, size_t i_buf_size,
+                                 size_t i_es_dscr_length, size_t i_dec_dscr_length,
+                                 uint8_t *p_esds_buf)
+{
+    p_esds_buf[0] = 0x03;
+    p_esds_buf[1] = 0x80;
+    p_esds_buf[2] = 0x80;
+    p_esds_buf[3] = 0x80;
+    p_esds_buf[4] = i_es_dscr_length;
+    uint16_t *es_id = (uint16_t *)&p_esds_buf[5];
+    *es_id = htobe16(1);
+    
+    p_esds_buf[8] = 0x04;
+    p_esds_buf[9] = 0x80;
+    p_esds_buf[10] = 0x80;
+    p_esds_buf[11] = 0x80;
+    p_esds_buf[12] = i_dec_dscr_length;
+    p_esds_buf[13] = 0x20;
+    p_esds_buf[14] = 0x11;
+    uint32_t *max_br = (uint32_t *)&p_esds_buf[18];
+    uint32_t *avg_br = (uint32_t *)&p_esds_buf[22];
+    *max_br = *avg_br = htobe32(codecpar->bit_rate);
+
+    p_esds_buf[26] = 0x05;
+    p_esds_buf[27] = 0x80;
+    p_esds_buf[28] = 0x80;
+    p_esds_buf[29] = 0x80;
+    p_esds_buf[30] = i_buf_size;
+    memcpy(&p_esds_buf[31], p_buf, i_buf_size);
+
+    p_esds_buf[31+i_buf_size] = 0x06;
+    p_esds_buf[31+i_buf_size+1] = 0x80;
+    p_esds_buf[31+i_buf_size+2] = 0x80;
+    p_esds_buf[31+i_buf_size+3] = 0x80;
+    p_esds_buf[31+i_buf_size+4] = 0x01;
+    p_esds_buf[31+i_buf_size+5] = 0x02;
+}

--- a/ijkmedia/ijkplayer/android/pipeline/mpeg4_esds.h
+++ b/ijkmedia/ijkplayer/android/pipeline/mpeg4_esds.h
@@ -1,5 +1,5 @@
 /*
- * hevc_nal.h
+ * mpeg4_esds.h
  * 
  * Copyright (c) 2015 yuazhen <zhengyuan10503@gmail.com>
  *

--- a/ijkmedia/ijkplayer/ff_ffplay_def.h
+++ b/ijkmedia/ijkplayer/ff_ffplay_def.h
@@ -621,6 +621,7 @@ typedef struct FFPlayer {
     int mediacodec_avc;
     int mediacodec_hevc;
     int mediacodec_mpeg2;
+    int mediacodec_mpeg4;
     int mediacodec_handle_resolution_change;
     int mediacodec_auto_rotate;
 

--- a/ijkmedia/ijkplayer/ff_ffplay_options.h
+++ b/ijkmedia/ijkplayer/ff_ffplay_options.h
@@ -169,6 +169,8 @@ static const AVOption ffp_context_options[] = {
         OPTION_OFFSET(mediacodec_hevc),         OPTION_INT(0, 0, 1) },
     { "mediacodec-mpeg2",                       "MediaCodec: enable MPEG2VIDEO",
         OPTION_OFFSET(mediacodec_mpeg2),        OPTION_INT(0, 0, 1) },
+    { "mediacodec-mpeg4",                       "MediaCodec: enable MPEG4",
+        OPTION_OFFSET(mediacodec_mpeg4),        OPTION_INT(0, 0, 1) },
     { "mediacodec-handle-resolution-change",                    "MediaCodec: handle resolution change automatically",
         OPTION_OFFSET(mediacodec_handle_resolution_change),     OPTION_INT(0, 0, 1) },
     { "opensles",                           "OpenSL ES: enable",


### PR DESCRIPTION
According to the instructions on the https://developer.android.com/reference/android/media/MediaCodec.html, when playing mpeg4 encoded video, the esds data must be submitted to csd-0 buffer, so I added a method named " restore_mpeg4_esds ", when enabled mediacodec_mpeg4 the esds data will be restored from codecpar-> extradata and submitted to csd-0 buffer, so that mpeg4 can be correctly decoded by mediacodec.
The implementation of "restore_mpeg4_esds" is referenced to http://xhelmboyx.tripod.com/formats/mp4-layout.txt "ES Descriptor box" section.
HOWEVER, not all devices can support DivX, so in ffpipenode_create_video_decoder_from_android_mediacodec() there's a filter using codec_tag to determine whether the video encoding is DivX or not.
AND this patch could solve issue #1428 