### PR TITLE
fix wrong timestamp when pts is AV_NOPTS_VALUE

### DIFF
--- a/ijkmedia/ijkplayer/android/pipeline/ffpipenode_android_mediacodec_vdec.c
+++ b/ijkmedia/ijkplayer/android/pipeline/ffpipenode_android_mediacodec_vdec.c
@@ -655,9 +655,9 @@ static int feed_input_buffer(JNIEnv *env, IJKFF_Pipenode *node, int64_t timeUs, 
         }
 
         time_stamp = d->pkt_temp.pts;
-        if (!time_stamp && d->pkt_temp.dts)
+        if (time_stamp == AV_NOPTS_VALUE && d->pkt_temp.dts != AV_NOPTS_VALUE)
             time_stamp = d->pkt_temp.dts;
-        if (time_stamp > 0) {
+        if (time_stamp >= 0) {
             time_stamp = av_rescale_q(time_stamp, is->video_st->time_base, AV_TIME_BASE_Q);
         } else {
             time_stamp = 0;


### PR DESCRIPTION
ffmpeg sometimes fails to get the correct PTS from some stream, and it will assign AV_NOPTS_VALUE to AVPacket.pts, but AV_NOPTS_VALUE is not 0.
when playing those streams, according to whether the AVPacket.pts is 0 or not to determine if it's a valid PTS, will get the wrong 'timestamp', that is 0, will lead to A/V out of sync on some devices.
sample stream can be found on https://pan.baidu.com/s/1pL4IiFL