### PR TITLE
Update ExoPlayer to 1.5.11

### DIFF
--- a/android/ijkplayer/ijkplayer-exo/build.gradle
+++ b/android/ijkplayer/ijkplayer-exo/build.gradle
@@ -25,7 +25,7 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
 
-    compile 'com.google.android.exoplayer:exoplayer:r1.5.9'
+    compile 'com.google.android.exoplayer:exoplayer:r1.5.11'
 
     compile project(':ijkplayer-java')
     // compile 'tv.danmaku.ijk.media:ijkplayer-java:0.6.2'

--- a/android/ijkplayer/ijkplayer-exo/src/main/java/tv/danmaku/ijk/media/exo/demo/EventLogger.java
+++ b/android/ijkplayer/ijkplayer-exo/src/main/java/tv/danmaku/ijk/media/exo/demo/EventLogger.java
@@ -15,6 +15,9 @@
  */
 package tv.danmaku.ijk.media.exo.demo;
 
+import android.media.MediaCodec.CryptoException;
+import android.os.SystemClock;
+import android.util.Log;
 import com.google.android.exoplayer.ExoPlayer;
 import com.google.android.exoplayer.MediaCodecTrackRenderer.DecoderInitializationException;
 import com.google.android.exoplayer.TimeRange;
@@ -22,14 +25,10 @@ import com.google.android.exoplayer.audio.AudioTrack;
 import com.google.android.exoplayer.chunk.Format;
 import tv.danmaku.ijk.media.exo.demo.player.DemoPlayer;
 import com.google.android.exoplayer.util.VerboseLogUtil;
-
-import android.media.MediaCodec.CryptoException;
-import android.os.SystemClock;
-import android.util.Log;
-
 import java.io.IOException;
 import java.text.NumberFormat;
 import java.util.Locale;
+
 
 /**
  * Logs player events using {link Log}.

--- a/android/ijkplayer/ijkplayer-exo/src/main/java/tv/danmaku/ijk/media/exo/demo/SmoothStreamingTestMediaDrmCallback.java
+++ b/android/ijkplayer/ijkplayer-exo/src/main/java/tv/danmaku/ijk/media/exo/demo/SmoothStreamingTestMediaDrmCallback.java
@@ -15,19 +15,20 @@
  */
 package tv.danmaku.ijk.media.exo.demo;
 
-import com.google.android.exoplayer.drm.MediaDrmCallback;
-import com.google.android.exoplayer.drm.StreamingDrmSessionManager;
-import com.google.android.exoplayer.util.Util;
-
 import android.annotation.TargetApi;
-import android.media.MediaDrm.KeyRequest;
-import android.media.MediaDrm.ProvisionRequest;
 import android.text.TextUtils;
 
+import com.google.android.exoplayer.drm.ExoMediaDrm.KeyRequest;
+import com.google.android.exoplayer.drm.ExoMediaDrm.ProvisionRequest;
+import com.google.android.exoplayer.drm.MediaDrmCallback;
+import com.google.android.exoplayer.util.Util;
+
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+
 
 /**
  * Demo {link StreamingDrmSessionManager} for smooth streaming test content.
@@ -37,6 +38,8 @@ public class SmoothStreamingTestMediaDrmCallback implements MediaDrmCallback {
 
   private static final String PLAYREADY_TEST_DEFAULT_URI =
       "http://playready.directtaps.net/pr/svc/rightsmanager.asmx";
+  private static final Map<String, String> PROVISIONING_REQUEST_PROPERTIES =
+          Collections.singletonMap("Content-Type", "application/octet-stream");
   private static final Map<String, String> KEY_REQUEST_PROPERTIES;
   static {
     HashMap<String, String> keyRequestProperties = new HashMap<>();
@@ -49,7 +52,7 @@ public class SmoothStreamingTestMediaDrmCallback implements MediaDrmCallback {
   @Override
   public byte[] executeProvisionRequest(UUID uuid, ProvisionRequest request) throws IOException {
     String url = request.getDefaultUrl() + "&signedRequest=" + new String(request.getData());
-    return Util.executePost(url, null, null);
+    return Util.executePost(url, null, PROVISIONING_REQUEST_PROPERTIES);
   }
 
   @Override

--- a/android/ijkplayer/ijkplayer-exo/src/main/java/tv/danmaku/ijk/media/exo/demo/player/DashRendererBuilder.java
+++ b/android/ijkplayer/ijkplayer-exo/src/main/java/tv/danmaku/ijk/media/exo/demo/player/DashRendererBuilder.java
@@ -15,6 +15,11 @@
  */
 package tv.danmaku.ijk.media.exo.demo.player;
 
+import android.content.Context;
+import android.media.AudioManager;
+import android.media.MediaCodec;
+import android.os.Handler;
+import android.util.Log;
 import com.google.android.exoplayer.DefaultLoadControl;
 import com.google.android.exoplayer.LoadControl;
 import com.google.android.exoplayer.MediaCodecAudioTrackRenderer;
@@ -34,7 +39,7 @@ import com.google.android.exoplayer.dash.mpd.Period;
 import com.google.android.exoplayer.dash.mpd.UtcTimingElement;
 import com.google.android.exoplayer.dash.mpd.UtcTimingElementResolver;
 import com.google.android.exoplayer.dash.mpd.UtcTimingElementResolver.UtcTimingCallback;
-import tv.danmaku.ijk.media.exo.demo.player.DemoPlayer.RendererBuilder;
+import com.google.android.exoplayer.drm.FrameworkMediaCrypto;
 import com.google.android.exoplayer.drm.MediaDrmCallback;
 import com.google.android.exoplayer.drm.StreamingDrmSessionManager;
 import com.google.android.exoplayer.drm.UnsupportedDrmException;
@@ -46,19 +51,12 @@ import com.google.android.exoplayer.upstream.DefaultUriDataSource;
 import com.google.android.exoplayer.upstream.UriDataSource;
 import com.google.android.exoplayer.util.ManifestFetcher;
 import com.google.android.exoplayer.util.Util;
-
-import android.content.Context;
-import android.media.AudioManager;
-import android.media.MediaCodec;
-import android.os.Handler;
-import android.util.Log;
-
 import java.io.IOException;
 
 /**
  * A {link RendererBuilder} for DASH.
  */
-public class DashRendererBuilder implements RendererBuilder {
+public class DashRendererBuilder implements DemoPlayer.RendererBuilder {
 
   private static final String TAG = "DashRendererBuilder";
 
@@ -195,7 +193,7 @@ public class DashRendererBuilder implements RendererBuilder {
 
       // Check drm support if necessary.
       boolean filterHdContent = false;
-      StreamingDrmSessionManager drmSessionManager = null;
+      StreamingDrmSessionManager<FrameworkMediaCrypto> drmSessionManager = null;
       if (hasContentProtection) {
         if (Util.SDK_INT < 18) {
           player.onRenderersError(

--- a/android/ijkplayer/ijkplayer-exo/src/main/java/tv/danmaku/ijk/media/exo/demo/player/DemoPlayer.java
+++ b/android/ijkplayer/ijkplayer-exo/src/main/java/tv/danmaku/ijk/media/exo/demo/player/DemoPlayer.java
@@ -15,6 +15,10 @@
  */
 package tv.danmaku.ijk.media.exo.demo.player;
 
+import android.media.MediaCodec.CryptoException;
+import android.os.Handler;
+import android.os.Looper;
+import android.view.Surface;
 import com.google.android.exoplayer.CodecCounters;
 import com.google.android.exoplayer.DummyTrackRenderer;
 import com.google.android.exoplayer.ExoPlaybackException;
@@ -42,12 +46,6 @@ import com.google.android.exoplayer.upstream.BandwidthMeter;
 import com.google.android.exoplayer.upstream.DefaultBandwidthMeter;
 import com.google.android.exoplayer.util.DebugTextViewHelper;
 import com.google.android.exoplayer.util.PlayerControl;
-
-import android.media.MediaCodec.CryptoException;
-import android.os.Handler;
-import android.os.Looper;
-import android.view.Surface;
-
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;

--- a/android/ijkplayer/ijkplayer-exo/src/main/java/tv/danmaku/ijk/media/exo/demo/player/HlsRendererBuilder.java
+++ b/android/ijkplayer/ijkplayer-exo/src/main/java/tv/danmaku/ijk/media/exo/demo/player/HlsRendererBuilder.java
@@ -15,6 +15,11 @@
  */
 package tv.danmaku.ijk.media.exo.demo.player;
 
+import android.content.Context;
+import android.media.AudioManager;
+import android.media.MediaCodec;
+import android.os.Handler;
+
 import com.google.android.exoplayer.DefaultLoadControl;
 import com.google.android.exoplayer.LoadControl;
 import com.google.android.exoplayer.MediaCodecAudioTrackRenderer;
@@ -23,7 +28,6 @@ import com.google.android.exoplayer.MediaCodecVideoTrackRenderer;
 import com.google.android.exoplayer.SampleSource;
 import com.google.android.exoplayer.TrackRenderer;
 import com.google.android.exoplayer.audio.AudioCapabilities;
-import tv.danmaku.ijk.media.exo.demo.player.DemoPlayer.RendererBuilder;
 import com.google.android.exoplayer.hls.DefaultHlsTrackSelector;
 import com.google.android.exoplayer.hls.HlsChunkSource;
 import com.google.android.exoplayer.hls.HlsMasterPlaylist;
@@ -43,13 +47,10 @@ import com.google.android.exoplayer.upstream.DefaultUriDataSource;
 import com.google.android.exoplayer.util.ManifestFetcher;
 import com.google.android.exoplayer.util.ManifestFetcher.ManifestCallback;
 
-import android.content.Context;
-import android.media.AudioManager;
-import android.media.MediaCodec;
-import android.os.Handler;
-
 import java.io.IOException;
 import java.util.List;
+
+import tv.danmaku.ijk.media.exo.demo.player.DemoPlayer.RendererBuilder;
 
 /**
  * A {link RendererBuilder} for HLS.
@@ -145,7 +146,7 @@ public class HlsRendererBuilder implements RendererBuilder {
       DataSource dataSource = new DefaultUriDataSource(context, bandwidthMeter, userAgent);
       HlsChunkSource chunkSource = new HlsChunkSource(true /* isMaster */, dataSource, manifest,
           DefaultHlsTrackSelector.newDefaultInstance(context), bandwidthMeter,
-          timestampAdjusterProvider, HlsChunkSource.ADAPTIVE_MODE_SPLICE);
+          timestampAdjusterProvider);
       HlsSampleSource sampleSource = new HlsSampleSource(chunkSource, loadControl,
           MAIN_BUFFER_SEGMENTS * BUFFER_SEGMENT_SIZE, mainHandler, player, DemoPlayer.TYPE_VIDEO);
       MediaCodecVideoTrackRenderer videoRenderer = new MediaCodecVideoTrackRenderer(context,
@@ -160,7 +161,7 @@ public class HlsRendererBuilder implements RendererBuilder {
         DataSource audioDataSource = new DefaultUriDataSource(context, bandwidthMeter, userAgent);
         HlsChunkSource audioChunkSource = new HlsChunkSource(false /* isMaster */, audioDataSource,
             manifest, DefaultHlsTrackSelector.newAudioInstance(), bandwidthMeter,
-            timestampAdjusterProvider, HlsChunkSource.ADAPTIVE_MODE_SPLICE);
+            timestampAdjusterProvider);
         HlsSampleSource audioSampleSource = new HlsSampleSource(audioChunkSource, loadControl,
             AUDIO_BUFFER_SEGMENTS * BUFFER_SEGMENT_SIZE, mainHandler, player,
             DemoPlayer.TYPE_AUDIO);
@@ -180,7 +181,7 @@ public class HlsRendererBuilder implements RendererBuilder {
         DataSource textDataSource = new DefaultUriDataSource(context, bandwidthMeter, userAgent);
         HlsChunkSource textChunkSource = new HlsChunkSource(false /* isMaster */, textDataSource,
             manifest, DefaultHlsTrackSelector.newSubtitleInstance(), bandwidthMeter,
-            timestampAdjusterProvider, HlsChunkSource.ADAPTIVE_MODE_SPLICE);
+            timestampAdjusterProvider);
         HlsSampleSource textSampleSource = new HlsSampleSource(textChunkSource, loadControl,
             TEXT_BUFFER_SEGMENTS * BUFFER_SEGMENT_SIZE, mainHandler, player, DemoPlayer.TYPE_TEXT);
         textRenderer = new TextTrackRenderer(textSampleSource, player, mainHandler.getLooper());

--- a/init-android-exo.sh
+++ b/init-android-exo.sh
@@ -17,7 +17,7 @@
 
 IJK_EXO_UPSTREAM=https://github.com/google/ExoPlayer.git
 IJK_EXO_FORK=https://github.com/google/ExoPlayer.git
-IJK_EXO_COMMIT=r1.5.9
+IJK_EXO_COMMIT=r1.5.11
 IJK_EXO_LOCAL_REPO=extra/ExoPlayer
 
 set -e


### PR DESCRIPTION
Updated ExoPlayer lib to 1.5.11 version.
Btw, there is brand new release with a lot of new opportunities - Exoplayer 2.0, but it seems that a lot of work needed to update. Moreover it is better to wait when it will become more stable. 