### PR TITLE
Correct Package name in x86_64 AndroidManifest

### DIFF
--- a/android/ijkplayer/ijkplayer-x86_64/src/main/AndroidManifest.xml
+++ b/android/ijkplayer/ijkplayer-x86_64/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.ijkplayer_x86_64">
+    package="tv.danmaku.ijk.media.player_x86_64">
 
     <uses-sdk
         android:minSdkVersion="21" />


### PR DESCRIPTION
This brings the x86_64 package name inline with the rest of the project.
