### PR TITLE
Add support for urls with RTMP scheme in iOS Demo app

### DIFF
--- a/ios/IJKMediaDemo/IJKMediaDemo/IJKDemoInputURLViewController.m
+++ b/ios/IJKMediaDemo/IJKMediaDemo/IJKDemoInputURLViewController.m
@@ -43,7 +43,9 @@
     NSURL *url = [NSURL URLWithString:self.textView.text];
     NSString *scheme = [[url scheme] lowercaseString];
     
-    if ([scheme isEqualToString:@"http"] || [scheme isEqualToString:@"https"]) {
+    if ([scheme isEqualToString:@"http"]
+        || [scheme isEqualToString:@"https"]
+        || [scheme isEqualToString:@"rtmp"]) {
         [IJKVideoViewController presentFromViewController:self withTitle:[NSString stringWithFormat:@"URL: %@", url] URL:url completion:^{
 //            [self.navigationController popViewControllerAnimated:NO];
         }];


### PR DESCRIPTION
IJKMediaDemo app now filters url input by rejecting anything with schemes other than http/https.

This PR add support for RTMP scheme, which has been tested in a LAN environment.