### PR TITLE
Fix issue #1774 and #1751

### DIFF
--- a/ios/IJKMediaPlayer/IJKMediaPlayer/ijkmedia/ijkplayer/ios/pipeline/IJKVideoToolBox.m
+++ b/ios/IJKMediaPlayer/IJKMediaPlayer/ijkmedia/ijkplayer/ios/pipeline/IJKVideoToolBox.m
@@ -1178,6 +1178,7 @@ VideoToolBoxContext* videotoolbox_create(FFPlayer* ffp, AVCodecContext* avctx)
     if (ret)
         goto fail;
     assert(context_vtb->fmt_desc.fmt_desc);
+    vtbformat_destroy(&context_vtb->fmt_desc);
 
     context_vtb->vt_session = vtbsession_create(context_vtb);
     if (context_vtb->vt_session == NULL)


### PR DESCRIPTION
When setPlayerOptionIntValue as 1 for key "videotoolbox" in IJKFFOptions object, it appears memory leak.

Also fix issue #1774 and #1751.