### PR TITLE
To avoid the Meizu or GIONEE nullpointexception crash when the callback was invoked

### DIFF
--- a/android/ijkplayer/ijkplayer-java/src/main/java/tv/danmaku/ijk/media/player/AndroidMediaPlayer.java
+++ b/android/ijkplayer/ijkplayer-java/src/main/java/tv/danmaku/ijk/media/player/AndroidMediaPlayer.java
@@ -425,6 +425,10 @@ public class AndroidMediaPlayer extends AbstractMediaPlayer {
             if (self == null)
                 return;
 
+            //To avoid the Meizu or GIONEE crash when the callback was invoked.
+            if (text == null)
+                return;
+
             IjkTimedText ijkText = new IjkTimedText(text.getBounds(), text.getText());
             notifyOnTimedText(ijkText);
         }


### PR DESCRIPTION
I use tv.danmaku.ijk.media:ijkplayer-java:0.7.7.1 ,and when my app is published.i has found some nullpointexception on Meizu and some GIONEE mobile phone. 
below is the crash log's screenshot,
<img width="921" alt="qq20170220-221558 2x" src="https://cloud.githubusercontent.com/assets/4048832/23128521/37edfd6a-f7ba-11e6-95fe-0af5ec8fd487.png">

