### PR TITLE
fix while seek, play previous sound before play new sound

### DIFF
--- a/ijkmedia/ijksdl/ffmpeg/ijksdl_vout_overlay_ffmpeg.c
+++ b/ijkmedia/ijksdl/ffmpeg/ijksdl_vout_overlay_ffmpeg.c
@@ -175,7 +175,9 @@ static int func_fill_frame(SDL_VoutOverlay *overlay, const AVFrame *frame)
         case SDL_FCC_I420:
             if (frame->format == AV_PIX_FMT_YUV420P || frame->format == AV_PIX_FMT_YUVJ420P) {
                 // ALOGE("direct draw frame");
-                use_linked_frame = 1;
+#if defined(__ANDROID__)
+                use_linked_frame = 1;//wing modify@031617
+#endif
                 dst_format = frame->format;
             } else {
                 // ALOGE("copy draw frame");

--- a/ijkmedia/ijksdl/ffmpeg/ijksdl_vout_overlay_ffmpeg.c
+++ b/ijkmedia/ijksdl/ffmpeg/ijksdl_vout_overlay_ffmpeg.c
@@ -175,9 +175,9 @@ static int func_fill_frame(SDL_VoutOverlay *overlay, const AVFrame *frame)
         case SDL_FCC_I420:
             if (frame->format == AV_PIX_FMT_YUV420P || frame->format == AV_PIX_FMT_YUVJ420P) {
                 // ALOGE("direct draw frame");
-#if defined(__ANDROID__)
-                use_linked_frame = 1;//wing modify@031617
-#endif
+                if (frame->linesize[0] == 2*frame->linesize[1]) {
+                    use_linked_frame = 1;//wing modify@032417
+                }
                 dst_format = frame->format;
             } else {
                 // ALOGE("copy draw frame");

--- a/ios/IJKMediaPlayer/IJKMediaPlayer/ijkmedia/ijksdl/ios/IJKSDLAudioQueueController.m
+++ b/ios/IJKMediaPlayer/IJKMediaPlayer/ijkmedia/ijksdl/ios/IJKSDLAudioQueueController.m
@@ -217,7 +217,6 @@
     // do not lock AudioQueueStop, or may be run into deadlock
     AudioQueueStop(_audioQueueRef, true);
     AudioQueueDispose(_audioQueueRef, true);
-    [self freeAudioQueueBuffers];
 }
 
 - (void)close

--- a/ios/IJKMediaPlayer/IJKMediaPlayer/ijkmedia/ijksdl/ios/IJKSDLAudioQueueController.m
+++ b/ios/IJKMediaPlayer/IJKMediaPlayer/ijkmedia/ijksdl/ios/IJKSDLAudioQueueController.m
@@ -29,7 +29,7 @@
 
 #import <AVFoundation/AVFoundation.h>
 
-#define kIJKAudioQueueNumberBuffers (3)
+#define kIJKAudioQueueNumberBuffers (2)
 
 @implementation IJKSDLAudioQueueController {
     AudioQueueRef _audioQueueRef;
@@ -39,6 +39,28 @@
 
     volatile BOOL _isAborted;
     NSLock *_lock;
+}
+
+- (void) allocateAudioQueueBuffers {
+    for (int i = 0; i < kIJKAudioQueueNumberBuffers; i++)
+    {
+        if (!_audioQueueBufferRefArray[i]) {
+            AudioQueueAllocateBuffer(_audioQueueRef, _spec.size, &_audioQueueBufferRefArray[i]);
+            _audioQueueBufferRefArray[i]->mAudioDataByteSize = _spec.size;
+            memset(_audioQueueBufferRefArray[i]->mAudioData, 0, _spec.size);
+            AudioQueueEnqueueBuffer(_audioQueueRef, _audioQueueBufferRefArray[i], 0, NULL);
+        }
+    }
+}
+
+- (void) freeAudioQueueBuffers {
+    for (int i = 0; i < kIJKAudioQueueNumberBuffers; i++)
+    {
+        if (_audioQueueBufferRefArray[i]) {
+            AudioQueueFreeBuffer(_audioQueueRef, _audioQueueBufferRefArray[i]);
+            _audioQueueBufferRefArray[i] = NULL;
+        }
+    }
 }
 
 - (id)initWithAudioSpec:(const SDL_AudioSpec *)aSpec
@@ -140,15 +162,7 @@
         if (NO == [[AVAudioSession sharedInstance] setActive:YES error:&error]) {
             NSLog(@"AudioQueue: AVAudioSession.setActive(YES) failed: %@\n", error ? [error localizedDescription] : @"nil");
         }
-
-        for (int i = 0;i < kIJKAudioQueueNumberBuffers; i++)
-        {
-            AudioQueueAllocateBuffer(_audioQueueRef, _spec.size, &_audioQueueBufferRefArray[i]);
-            _audioQueueBufferRefArray[i]->mAudioDataByteSize = _spec.size;
-            memset(_audioQueueBufferRefArray[i]->mAudioData, 0, _spec.size);
-            AudioQueueEnqueueBuffer(_audioQueueRef, _audioQueueBufferRefArray[i], 0, NULL);
-        }
-        
+        [self allocateAudioQueueBuffers];
         OSStatus status = AudioQueueStart(_audioQueueRef, NULL);
         if (status != noErr)
             NSLog(@"AudioQueue: AudioQueueStart failed (%d)\n", (int)status);
@@ -171,6 +185,7 @@
         status = AudioQueueReset(_audioQueueRef);
         if (status != noErr)
             NSLog(@"AudioQueue: AudioQueueReset failed (%d)\n", (int)status);
+        [self freeAudioQueueBuffers];
     }
 }
 
@@ -202,6 +217,7 @@
     // do not lock AudioQueueStop, or may be run into deadlock
     AudioQueueStop(_audioQueueRef, true);
     AudioQueueDispose(_audioQueueRef, true);
+    [self freeAudioQueueBuffers];
 }
 
 - (void)close

--- a/ios/IJKMediaPlayer/IJKMediaPlayer/ijkmedia/ijksdl/ios/IJKSDLAudioQueueController.m
+++ b/ios/IJKMediaPlayer/IJKMediaPlayer/ijkmedia/ijksdl/ios/IJKSDLAudioQueueController.m
@@ -87,24 +87,25 @@
         propValue = kAudioQueueTimePitchAlgorithm_Spectral;
         AudioQueueSetProperty(_audioQueueRef, kAudioQueueProperty_TimePitchAlgorithm, &propValue, sizeof(propValue));
 
+        /*
         status = AudioQueueStart(audioQueueRef, NULL);
         if (status != noErr) {
             NSLog(@"AudioQueue: AudioQueueStart failed (%d)\n", (int)status);
             self = nil;
             return nil;
-        }
+        }*/
 
         SDL_CalculateAudioSpec(&_spec);
 
         _audioQueueRef = audioQueueRef;
-
+        /*
         for (int i = 0;i < kIJKAudioQueueNumberBuffers; i++)
         {
             AudioQueueAllocateBuffer(audioQueueRef, _spec.size, &_audioQueueBufferRefArray[i]);
             _audioQueueBufferRefArray[i]->mAudioDataByteSize = _spec.size;
             memset(_audioQueueBufferRefArray[i]->mAudioData, 0, _spec.size);
             AudioQueueEnqueueBuffer(audioQueueRef, _audioQueueBufferRefArray[i], 0, NULL);
-        }
+        }*/
         /*-
         status = AudioQueueStart(audioQueueRef, NULL);
         if (status != noErr) {
@@ -140,6 +141,14 @@
             NSLog(@"AudioQueue: AVAudioSession.setActive(YES) failed: %@\n", error ? [error localizedDescription] : @"nil");
         }
 
+        for (int i = 0;i < kIJKAudioQueueNumberBuffers; i++)
+        {
+            AudioQueueAllocateBuffer(_audioQueueRef, _spec.size, &_audioQueueBufferRefArray[i]);
+            _audioQueueBufferRefArray[i]->mAudioDataByteSize = _spec.size;
+            memset(_audioQueueBufferRefArray[i]->mAudioData, 0, _spec.size);
+            AudioQueueEnqueueBuffer(_audioQueueRef, _audioQueueBufferRefArray[i], 0, NULL);
+        }
+        
         OSStatus status = AudioQueueStart(_audioQueueRef, NULL);
         if (status != noErr)
             NSLog(@"AudioQueue: AudioQueueStart failed (%d)\n", (int)status);
@@ -159,6 +168,9 @@
         OSStatus status = AudioQueuePause(_audioQueueRef);
         if (status != noErr)
             NSLog(@"AudioQueue: AudioQueuePause failed (%d)\n", (int)status);
+        status = AudioQueueReset(_audioQueueRef);
+        if (status != noErr)
+            NSLog(@"AudioQueue: AudioQueueReset failed (%d)\n", (int)status);
     }
 }
 


### PR DESCRIPTION
问题现象：
1.当 seek 后会播放之前位置的音频，长度为0.2s那样子，然后才会开始播放seek后的音频。
2.暂停状态时seek 后也会出现播放长度为0.2s的之前位置的音频。
解决方法：通过清除之前audio queue缓冲队列解决