### PR TITLE
fix some video display green side after rotate

### DIFF
--- a/ijkmedia/ijksdl/ffmpeg/ijksdl_vout_overlay_ffmpeg.c
+++ b/ijkmedia/ijksdl/ffmpeg/ijksdl_vout_overlay_ffmpeg.c
@@ -175,7 +175,9 @@ static int func_fill_frame(SDL_VoutOverlay *overlay, const AVFrame *frame)
         case SDL_FCC_I420:
             if (frame->format == AV_PIX_FMT_YUV420P || frame->format == AV_PIX_FMT_YUVJ420P) {
                 // ALOGE("direct draw frame");
-                use_linked_frame = 1;
+                if (frame->linesize[0] == 2*frame->linesize[1]) {
+                    use_linked_frame = 1;
+                }
                 dst_format = frame->format;
             } else {
                 // ALOGE("copy draw frame");


### PR DESCRIPTION
after rotation,  some video display with green side cause by `linesize[0] != 2*linesize[1]` in YUV420P mode.   Reference：`glTexImage2D` render YUV420P