### PR TITLE
Fix memory leak (if not call prepareToPlay, The IJKFFMoviePlayerContr…

### DIFF
--- a/ios/IJKMediaPlayer/IJKMediaPlayer/IJKFFMoviePlayerController.m
+++ b/ios/IJKMediaPlayer/IJKMediaPlayer/IJKFFMoviePlayerController.m
@@ -326,9 +326,6 @@ void IJKFFIOStatCompleteRegister(void (*cb)(const char *url,
 
     [self stopHudTimer];
     ijkmp_stop(_mediaPlayer);
-    
-    IJKFFMoviePlayerController *ffpController = (__bridge_transfer IJKFFMoviePlayerController *)ijkmp_set_weak_thiz(_mediaPlayer, NULL);
-    ffpController = nil;
 }
 
 - (BOOL)isPlaying
@@ -483,6 +480,7 @@ inline static int getPlayerOption(IJKFFOptionCategory category)
     _liveOpenDelegate       = nil;
     _nativeInvokeDelegate   = nil;
 
+    __unused id weakPlayer = (__bridge_transfer IJKFFMoviePlayerController*)ijkmp_set_weak_thiz(_mediaPlayer, NULL);
     __unused id weakHolder = (__bridge_transfer IJKWeakHolder*)ijkmp_set_inject_opaque(_mediaPlayer, NULL);
     __unused id weakijkHolder = (__bridge_transfer IJKWeakHolder*)ijkmp_set_ijkio_inject_opaque(_mediaPlayer, NULL);
     ijkmp_dec_ref_p(&_mediaPlayer);

--- a/ios/IJKMediaPlayer/IJKMediaPlayer/IJKFFMoviePlayerController.m
+++ b/ios/IJKMediaPlayer/IJKMediaPlayer/IJKFFMoviePlayerController.m
@@ -326,6 +326,9 @@ void IJKFFIOStatCompleteRegister(void (*cb)(const char *url,
 
     [self stopHudTimer];
     ijkmp_stop(_mediaPlayer);
+    
+    IJKFFMoviePlayerController *ffpController = (__bridge_transfer IJKFFMoviePlayerController *)ijkmp_set_weak_thiz(_mediaPlayer, NULL);
+    ffpController = nil;
 }
 
 - (BOOL)isPlaying

--- a/ios/IJKMediaPlayer/IJKMediaPlayer/ijkmedia/ijkplayer/ios/pipeline/IJKVideoToolBoxAsync.m
+++ b/ios/IJKMediaPlayer/IJKMediaPlayer/ijkmedia/ijkplayer/ios/pipeline/IJKVideoToolBoxAsync.m
@@ -285,7 +285,8 @@ static CMSampleBufferRef CreateSampleBufferFrom(CMFormatDescriptionRef fmt_desc,
                                       &sBufOut);
     }
 
-    CFRelease(newBBufOut);
+    if (newBBufOut)
+        CFRelease(newBBufOut);
     if (status == 0) {
         return sBufOut;
     } else {

--- a/ios/IJKMediaPlayer/IJKMediaPlayer/ijkmedia/ijkplayer/ios/pipeline/IJKVideoToolBoxSync.m
+++ b/ios/IJKMediaPlayer/IJKMediaPlayer/ijkmedia/ijkplayer/ios/pipeline/IJKVideoToolBoxSync.m
@@ -199,7 +199,8 @@ static CMSampleBufferRef CreateSampleBufferFrom(CMFormatDescriptionRef fmt_desc,
                                       &sBufOut);
     }
 
-    CFRelease(newBBufOut);
+    if (newBBufOut)
+        CFRelease(newBBufOut);
     if (status == 0) {
         return sBufOut;
     } else {


### PR DESCRIPTION
If create the IJKFFMoviePlayerController，but don't call the prepareToPlay method，there will be memory leak of IJKFFMoviePlayerController