### PR TITLE
Fix reconfigure codec randomly crash.

### DIFF
--- a/ijkmedia/ijkplayer/android/pipeline/ffpipenode_android_mediacodec_vdec.c
+++ b/ijkmedia/ijkplayer/android/pipeline/ffpipenode_android_mediacodec_vdec.c
@@ -307,6 +307,7 @@ static int reconfigure_codec_l(JNIEnv *env, IJKFF_Pipenode *node, jobject new_su
             if (opaque->quirk_reconfigure_with_new_codec) {
                 ALOGI("quirk: reconfigure with new codec");
                 SDL_AMediaCodec_decreaseReferenceP(&opaque->acodec);
+                SDL_VoutAndroid_setAMediaCodec(opaque->weak_vout, NULL);
 
                 opaque->acodec = create_codec_l(env, node);
                 if (!opaque->acodec) {


### PR DESCRIPTION
ijkplayer used to stop previous mediacodec & create a new mediacodec, then release previous. 

background knowledge:
vendor vdec drv init, checking codec & alloc framebuffer to hw, the framebuffer will returned to memmap until call the deinit.

in android native mediacodec impl:
mediacodec stop do not deinit omx component(just changed omx state to idle), continues create a new mediacodec would lead some vendor drv notify err(ex :InsufficientResources) due to memory is not enough or vendor hw limitation(one instance).

this case is not appeared in android mediaplayer becoz nuplayer would release previous mediacodec then create a new one.

solution: release previous mediacodec then create a new one when reconfigure codec.