### PR TITLE
Update ijkplayer.c

### DIFF
--- a/ijkmedia/ijkplayer/ijkplayer.c
+++ b/ijkmedia/ijkplayer/ijkplayer.c
@@ -694,9 +694,9 @@ int ijkmp_get_msg(IjkMediaPlayer *mp, AVMessage *msg, int block)
             } else {
                 // FIXME: 1: onError() ?
                 av_log(mp->ffplayer, AV_LOG_DEBUG, "FFP_MSG_PREPARED: expecting mp_state==MP_STATE_ASYNC_PREPARING\n");
-            }
-            if (ffp_is_paused_l(mp->ffplayer)) {
-                ijkmp_change_state_l(mp, MP_STATE_PAUSED);
+                if (ffp_is_paused_l(mp->ffplayer)) {
+                    ijkmp_change_state_l(mp, MP_STATE_PAUSED);
+                }
             }
             pthread_mutex_unlock(&mp->mutex);
             break;


### PR DESCRIPTION
当使用"seek-at-start"参数的时候，已经播放的视频有很大概率is->paused是1，导致设置了错误的state。我不清楚当初为啥要多判断一下ffp_is_paused_l()。或许有更好的解决办法。