### PR TITLE
修复了 iOS 上使用 IJKAVMoviePlayerController 截图时所得图片非当前帧的问题

### DIFF
--- a/ios/IJKMediaPlayer/IJKMediaPlayer/IJKAVMoviePlayerController.m
+++ b/ios/IJKMediaPlayer/IJKMediaPlayer/IJKAVMoviePlayerController.m
@@ -326,10 +326,19 @@ static IJKAVMoviePlayerController* instance;
 - (UIImage *)thumbnailImageAtCurrentTime
 {
     AVAssetImageGenerator *imageGenerator = [AVAssetImageGenerator assetImageGeneratorWithAsset:_playAsset];
-    NSError *error = nil;
-    CMTime time = CMTimeMakeWithSeconds(self.currentPlaybackTime, 1);
-    CMTime actualTime;
-    CGImageRef cgImage = [imageGenerator copyCGImageAtTime:time actualTime:&actualTime error:&error];
+    CMTime expectedTime = _playerItem.currentTime;
+    CGImageRef cgImage = NULL;
+    
+    imageGenerator.requestedTimeToleranceBefore = kCMTimeZero;
+    imageGenerator.requestedTimeToleranceAfter = kCMTimeZero;
+    cgImage = [imageGenerator copyCGImageAtTime:expectedTime actualTime:NULL error:NULL];
+    
+    if (!cgImage) {
+        imageGenerator.requestedTimeToleranceBefore = kCMTimePositiveInfinity;
+        imageGenerator.requestedTimeToleranceAfter = kCMTimePositiveInfinity;
+        cgImage = [imageGenerator copyCGImageAtTime:expectedTime actualTime:NULL error:NULL];
+    }
+    
     UIImage *image = [UIImage imageWithCGImage:cgImage];
     return image;
 }


### PR DESCRIPTION
**问题描述**  

当前版本，使用 iOS 系统播放器 `AVPlayer` 时，`IJKAVMoviePlayerController` 的截屏方法 `-thumbnailImageAtCurrentTime`，不能准确截取当前帧，且偏差较明显。

**问题原因**  

目前的实现方法，是使用 `AVAssetImageGenerator` 类的 `-copyCGImageAtTime:actualTime:error:` 方法，类似以下代码 (具体改动，参考 Pull Request 中的代码对比).
```
AVAssetImageGenerator *imageGenerator = [AVAssetImageGenerator assetImageGeneratorWithAsset:#avasset#];
CMTime expectedTime = #expected_time#;
CMTime actualTime;
CGImageRef cgImage = [imageGenerator copyCGImageAtTime:expectedTime actualTime:&actualTime error:&error];
```
然而，这一方法实际得到的截图对应的时间 (actualTime) 并不保证等于传入的期望时间 (expectedTime)。

**解决方案**  

截图用类 `AVAssetImageGenerator` 存在两个属性，`requestedTimeToleranceBefore` 和 `requestedTimeToleranceAfter`，用来限定，调用允许的偏差范围。这两个属性的默认值，均为 `kCMTimePositiveInfinity`，即不做任何限制，现设置为 `kCMTimeZero`，可保证截图所见即所得。

另外，根据官方文档中的描述，将 `requestedTimeToleranceBefore` 和 `requestedTimeToleranceAfter` 设置为 `kCMTimeZero`，可能会导致额外的解码延迟。实际测试，并未造成任何性能问题。

对这两个属性更详细的解释，可参考 Apple 官方文档：
https://developer.apple.com/documentation/avfoundation/avassetimagegenerator/1390571-requestedtimetolerancebefore?language=objc