### PR TITLE
android/example: release new useless surface, and reset surface to the e old which is held

### DIFF
--- a/android/ijkplayer/ijkplayer-example/src/main/java/tv/danmaku/ijk/media/example/widget/media/TextureRenderView.java
+++ b/android/ijkplayer/ijkplayer-example/src/main/java/tv/danmaku/ijk/media/example/widget/media/TextureRenderView.java
@@ -160,6 +160,12 @@ public class TextureRenderView extends TextureView implements IRenderView {
                 SurfaceTexture surfaceTexture = textureHolder.getSurfaceTexture();
                 if (surfaceTexture != null) {
                     mTextureView.setSurfaceTexture(surfaceTexture);
+                    // release new useless surface, and reset surface to the old which is held
+                    if (mSurfaceTexture != surfaceTexture) {
+                        mSurfaceTexture.release();
+                        mSurfaceTexture = surfaceTexture;
+                        mTextureView.mSurfaceCallback.mSurfaceTexture = surfaceTexture;
+                    }
                 } else {
                     textureHolder.setSurfaceTexture(mSurfaceTexture);
                     textureHolder.setSurfaceTextureHost(mTextureView.mSurfaceCallback);


### PR DESCRIPTION
启用holder后，在4.4系统偶现crash：java.lang.RuntimeException: Error during detachFromGLContext
定位原因是当多次创建TextureRenderView并home进入后会触发这段逻辑：
if (surfaceTexture != mSurfaceTexture) {
    Log.d(TAG, "releaseSurfaceTexture: alive: release different SurfaceTexture");
    surfaceTexture.release();
}
release正在使用的SurfaceTexture，是因为hold SurfaceTexture，home再进入后，会自动重新创建一个新的SurfaceTexture，这个SurfaceTexture变量被赋值给了mSurfaceTexture，应该设置为老的