### PR TITLE
Handle mediacodec unknown error

### DIFF
--- a/ijkmedia/ijkplayer/android/pipeline/ffpipenode_android_mediacodec_vdec.c
+++ b/ijkmedia/ijkplayer/android/pipeline/ffpipenode_android_mediacodec_vdec.c
@@ -1080,6 +1080,10 @@ static int drain_output_buffer_l(JNIEnv *env, IJKFF_Pipenode *node, int64_t time
     } else if (output_buffer_index == AMEDIACODEC__INFO_TRY_AGAIN_LATER) {
         AMCTRACE("AMEDIACODEC__INFO_TRY_AGAIN_LATER\n");
         // continue;
+    } else if (output_buffer_index == AMEDIACODEC__UNKNOWN_ERROR) {
+        ALOGI("AMEDIACODEC__UNKNOWN_ERROR\n");
+        ret = AMEDIACODEC_EXCEPTION;
+        goto fail;
     } else if (output_buffer_index < 0) {
         SDL_LockMutex(opaque->any_input_mutex);
         SDL_CondWaitTimeout(opaque->any_input_cond, opaque->any_input_mutex, 1000);
@@ -1543,7 +1547,9 @@ static int func_run_sync(IJKFF_Pipenode *node)
             SDL_UnlockMutex(opaque->acodec_first_dequeue_output_mutex);
         }
         if (ret != 0) {
-            ret = -1;
+            if (ret != AMEDIACODEC_EXCEPTION) {
+	        ret = -1;
+            }
             if (got_frame && frame->opaque)
                 SDL_VoutAndroid_releaseBufferProxyP(opaque->weak_vout, (SDL_AMediaCodecBufferProxy **)&frame->opaque, false);
             goto fail;

--- a/ijkmedia/ijkplayer/ff_ffpipenode.h
+++ b/ijkmedia/ijkplayer/ff_ffpipenode.h
@@ -26,6 +26,7 @@
 
 #include "ijksdl/ijksdl_mutex.h"
 
+#define AMEDIACODEC_EXCEPTION -666
 typedef struct IJKFF_Pipenode_Opaque IJKFF_Pipenode_Opaque;
 typedef struct IJKFF_Pipenode IJKFF_Pipenode;
 struct IJKFF_Pipenode {

--- a/ijkmedia/ijkplayer/ff_ffplay.c
+++ b/ijkmedia/ijkplayer/ff_ffplay.c
@@ -2158,6 +2158,12 @@ static int video_thread(void *arg)
     if (ffp->node_vdec) {
         ret = ffpipenode_run_sync(ffp->node_vdec);
     }
+    if (ret == AMEDIACODEC_EXCEPTION) {
+        ffp->node_vdec = ffpipenode_create_video_decoder_from_ffplay(ffp);
+        if (ffp->node_vdec) {
+            ret = ffpipenode_run_sync(ffp->node_vdec);
+        }
+    }
     return ret;
 }
 


### PR DESCRIPTION
问题描述：某些Android手机上，播放4K视频硬解码有异常，并且不会自动切换到软解码
解决方案：异常时返回特殊标志，重新创建软解码器