### PR TITLE
ios/videotoolbox: add function to support HEVC.

### DIFF
--- a/ijkmedia/ijkplayer/ff_ffplay_def.h
+++ b/ijkmedia/ijkplayer/ff_ffplay_def.h
@@ -660,6 +660,7 @@ typedef struct FFPlayer {
     int startup_volume;
 
     int videotoolbox;
+    int videotoolbox_hevc;
     int vtb_max_frame_width;
     int vtb_async;
     int vtb_wait_async;

--- a/ijkmedia/ijkplayer/ff_ffplay_options.h
+++ b/ijkmedia/ijkplayer/ff_ffplay_options.h
@@ -159,8 +159,10 @@ static const AVOption ffp_context_options[] = {
         OPTION_OFFSET(get_frame_mode),       OPTION_INT(0, 0, 1) },
 
         // iOS only options
-    { "videotoolbox",                       "VideoToolbox: enable",
+    { "videotoolbox",                       "VideoToolbox: enable H264",
         OPTION_OFFSET(videotoolbox),        OPTION_INT(0, 0, 1) },
+    { "videotoolbox-hevc",                  "VideoToolbox: enable HEVC",
+        OPTION_OFFSET(videotoolbox_hevc),   OPTION_INT(0, 0, 1) },
     { "videotoolbox-max-frame-width",       "VideoToolbox: max width of output frame",
         OPTION_OFFSET(vtb_max_frame_width), OPTION_INT(0, 0, INT_MAX) },
     { "videotoolbox-async",                 "VideoToolbox: use kVTDecodeFrame_EnableAsynchronousDecompression()",

--- a/ios/IJKMediaDemo/IJKMediaDemo/IJKDemoSampleViewController.m
+++ b/ios/IJKMediaDemo/IJKMediaDemo/IJKDemoSampleViewController.m
@@ -63,7 +63,8 @@
                             @"http://devimages.apple.com.edgekey.net/streaming/examples/bipbop_16x9/gear5/prog_index.m3u8"]];
     [sampleList addObject:@[@"bipbop advanced 22.050Hz stereo @ 40 kbps",
                             @"http://devimages.apple.com.edgekey.net/streaming/examples/bipbop_16x9/gear0/prog_index.m3u8"]];
-
+    [sampleList addObject:@[@"bipbop advanced hevc 170601 kbps",
+                            @"http://tungsten.aaplimg.com/VOD/img_bipbop_adv_example_hevc_ernie_170519_clr_ST322_v2_170601_final/master.m3u8"]];
     self.sampleList = sampleList;
 }
 

--- a/ios/IJKMediaPlayer/IJKMediaPlayer/IJKFFOptions.m
+++ b/ios/IJKMediaPlayer/IJKMediaPlayer/IJKFFOptions.m
@@ -42,6 +42,7 @@
     [options setPlayerOptionIntValue:0      forKey:@"framedrop"];
     [options setPlayerOptionIntValue:3      forKey:@"video-pictq-size"];
     [options setPlayerOptionIntValue:0      forKey:@"videotoolbox"];
+    [options setPlayerOptionIntValue:0      forKey:@"videotoolbox-hevc"];
     [options setPlayerOptionIntValue:960    forKey:@"videotoolbox-max-frame-width"];
 
     [options setFormatOptionIntValue:0                  forKey:@"auto_convert"];

--- a/ios/IJKMediaPlayer/IJKMediaPlayer/ijkmedia/ijkplayer/ios/pipeline/IJKVideoToolBoxSync.m
+++ b/ios/IJKMediaPlayer/IJKMediaPlayer/ijkmedia/ijkplayer/ios/pipeline/IJKVideoToolBoxSync.m
@@ -640,10 +640,12 @@ static int decode_video(Ijk_VideoToolBox_Opaque* context, AVCodecContext *avctx,
     }
 
     if (context->ffp->vtb_handle_resolution_change &&
-        context->codecpar->codec_id == AV_CODEC_ID_H264) {
+        (context->codecpar->codec_id == AV_CODEC_ID_H264 || context->codecpar->codec_id == AV_CODEC_ID_HEVC)) {
         size_data = av_packet_get_side_data(avpkt, AV_PKT_DATA_NEW_EXTRADATA, &size_data_size);
         // minimum avcC(sps,pps) = 7
-        if (size_data && size_data_size > 7) {
+        // minimum hvcC(vps,sps,pps) = 23
+        if ((context->codecpar->codec_id == AV_CODEC_ID_H264 && size_data && size_data_size > 7)
+            || (context->codecpar->codec_id == AV_CODEC_ID_HEVC && size_data && size_data_size > 23)) {
             int             got_picture = 0;
             AVFrame        *frame      = av_frame_alloc();
             AVDictionary   *codec_opts = NULL;
@@ -774,7 +776,10 @@ static CMFormatDescriptionRef CreateFormatDescriptionFromCodecData(Uint32 format
     dict_set_i32(par, CFSTR ("HorizontalSpacing"), 0);
     dict_set_i32(par, CFSTR ("VerticalSpacing"), 0);
     /* SampleDescriptionExtensionAtoms dict */
-    dict_set_data(atoms, CFSTR ("avcC"), (uint8_t *)extradata, extradata_size);
+    if(format_id == kCMVideoCodecType_H264)
+        dict_set_data(atoms, CFSTR ("avcC"), (uint8_t *)extradata, extradata_size);
+    else if(format_id == kCMVideoCodecType_HEVC)
+        dict_set_data(atoms, CFSTR ("hvcC"), (uint8_t *)extradata, extradata_size);
 
       /* Extensions dict */
     dict_set_string(extensions, CFSTR ("CVImageBufferChromaLocationBottomField"), "left");
@@ -978,6 +983,16 @@ static int vtbformat_init(VTBFormatDesc *fmt_desc, AVCodecParameters *codecpar)
                     ALOGI("%s - invalid avcC atom data", __FUNCTION__);
                     goto fail;
                 }
+            }
+            break;
+        case AV_CODEC_ID_HEVC:
+            if (extrasize < 23 || extradata == NULL) {
+                ALOGI("%s - hvcC atom too data small or missing", __FUNCTION__);
+                goto fail;
+            }
+            fmt_desc->fmt_desc = CreateFormatDescriptionFromCodecData(kCMVideoCodecType_HEVC, width, height, extradata, extrasize,  IJK_VTB_FCC_AVCC);
+            if (fmt_desc->fmt_desc == NULL) {
+                goto fail;
             }
             break;
         default:

--- a/ios/IJKMediaPlayer/IJKMediaPlayer/ijkmedia/ijkplayer/ios/pipeline/ffpipeline_ios.c
+++ b/ios/IJKMediaPlayer/IJKMediaPlayer/ijkmedia/ijkplayer/ios/pipeline/ffpipeline_ios.c
@@ -39,7 +39,7 @@ static IJKFF_Pipenode *func_open_video_decoder(IJKFF_Pipeline *pipeline, FFPlaye
 {
     IJKFF_Pipenode* node = NULL;
     IJKFF_Pipeline_Opaque *opaque = pipeline->opaque;
-    if (ffp->videotoolbox) {
+    if (ffp->videotoolbox || ffp->videotoolbox_hevc) {
         node = ffpipenode_create_video_decoder_from_ios_videotoolbox(ffp);
         if (!node)
             ALOGE("vtb fail!!! switch to ffmpeg decode!!!! \n");

--- a/ios/IJKMediaPlayer/IJKMediaPlayer/ijkmedia/ijkplayer/ios/pipeline/ffpipenode_ios_videotoolbox_vdec.m
+++ b/ios/IJKMediaPlayer/IJKMediaPlayer/ijkmedia/ijkplayer/ios/pipeline/ffpipenode_ios_videotoolbox_vdec.m
@@ -117,6 +117,16 @@ IJKFF_Pipenode *ffpipenode_create_video_decoder_from_ios_videotoolbox(FFPlayer *
             else
                 opaque->context = Ijk_VideoToolbox_Sync_Create(ffp, opaque->avctx);
         break;
+    case AV_CODEC_ID_HEVC: 
+            if(!ffp->videotoolbox_hevc) {
+                ALOGE("videotoolbox disable HEVC codec_id:%d\n", opaque->avctx->codec_id);
+                goto fail;
+            }
+            if (ffp->vtb_async)
+                opaque->context = Ijk_VideoToolbox_Async_Create(ffp, opaque->avctx);
+            else
+                opaque->context = Ijk_VideoToolbox_Sync_Create(ffp, opaque->avctx);
+        break;
     default:
         ALOGI("Videotoolbox-pipeline:open_video_decoder: not H264\n");
         goto fail;


### PR DESCRIPTION
fixed to support HEVC for ios videotoolbox.