### PR TITLE
Android Gradle plugin 3.1.1, s/compile/implementation/

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,17 +21,17 @@ allprojects {
 
 dependencies {
     # required, enough for most devices.
-    compile 'tv.danmaku.ijk.media:ijkplayer-java:0.8.8'
-    compile 'tv.danmaku.ijk.media:ijkplayer-armv7a:0.8.8'
+    implementation 'tv.danmaku.ijk.media:ijkplayer-java:0.8.8'
+    implementation 'tv.danmaku.ijk.media:ijkplayer-armv7a:0.8.8'
 
     # Other ABIs: optional
-    compile 'tv.danmaku.ijk.media:ijkplayer-armv5:0.8.8'
-    compile 'tv.danmaku.ijk.media:ijkplayer-arm64:0.8.8'
-    compile 'tv.danmaku.ijk.media:ijkplayer-x86:0.8.8'
-    compile 'tv.danmaku.ijk.media:ijkplayer-x86_64:0.8.8'
+    implementation 'tv.danmaku.ijk.media:ijkplayer-armv5:0.8.8'
+    implementation 'tv.danmaku.ijk.media:ijkplayer-arm64:0.8.8'
+    implementation 'tv.danmaku.ijk.media:ijkplayer-x86:0.8.8'
+    implementation 'tv.danmaku.ijk.media:ijkplayer-x86_64:0.8.8'
 
     # ExoPlayer as IMediaPlayer: optional, experimental
-    compile 'tv.danmaku.ijk.media:ijkplayer-exo:0.8.8'
+    implementation 'tv.danmaku.ijk.media:ijkplayer-exo:0.8.8'
 }
 ```
 - iOS

--- a/android/ijkplayer/build.gradle
+++ b/android/ijkplayer/build.gradle
@@ -3,9 +3,10 @@
 buildscript {
     repositories {
         jcenter()
+				google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.3'
+        classpath 'com.android.tools.build:gradle:3.1.1'
 
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7'
@@ -16,20 +17,17 @@ buildscript {
 
 allprojects {
     repositories {
+        google()
         jcenter()
     }
 }
 
 ext {
-    compileSdkVersion = 25
-    buildToolsVersion = "25.0.3"
+    compileSdkVersion = 27
+    buildToolsVersion = "27.0.3"
 
     targetSdkVersion = 25
 
     versionCode = 800800
     versionName = "0.8.8"
-}
-
-wrapper {
-    gradleVersion = '2.14.1'
 }

--- a/android/ijkplayer/gradle/wrapper/gradle-wrapper.properties
+++ b/android/ijkplayer/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/android/ijkplayer/ijkplayer-arm64/build.gradle
+++ b/android/ijkplayer/ijkplayer-arm64/build.gradle
@@ -23,8 +23,4 @@ android {
     }
 }
 
-dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-}
-
 apply from: new File(rootProject.projectDir, "tools/gradle-on-demand.gradle");

--- a/android/ijkplayer/ijkplayer-armv5/build.gradle
+++ b/android/ijkplayer/ijkplayer-armv5/build.gradle
@@ -23,8 +23,4 @@ android {
     }
 }
 
-dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-}
-
 apply from: new File(rootProject.projectDir, "tools/gradle-on-demand.gradle");

--- a/android/ijkplayer/ijkplayer-armv7a/build.gradle
+++ b/android/ijkplayer/ijkplayer-armv7a/build.gradle
@@ -23,8 +23,4 @@ android {
     }
 }
 
-dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-}
-
 apply from: new File(rootProject.projectDir, "tools/gradle-on-demand.gradle");

--- a/android/ijkplayer/ijkplayer-example/build.gradle
+++ b/android/ijkplayer/ijkplayer-example/build.gradle
@@ -23,53 +23,70 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    flavorDimensions "architecture"
+
     productFlavors {
-        all32 { minSdkVersion 9 }
-        all64 { minSdkVersion 21 }
-        // armv5 {}
-        // armv7a {}
-        // arm64 { minSdkVersion 21 }
-        // x86 {}
+        all32 {
+            minSdkVersion 9
+            dimension "architecture"
+        }
+        all64 {
+            minSdkVersion 21
+            dimension "architecture"
+        }
+        // armv5 {
+        //     dimension "architecture"
+        // }
+        // armv7a {
+        //     dimension "architecture"
+        // }
+        // arm64 {
+        //     minSdkVersion 21
+        //     dimension "architecture"
+        // }
+        // x86 {
+        //     dimension "architecture"
+        // }
     }
 }
 
 dependencies {
-    compile fileTree(include: ['*.jar'], dir: 'libs')
-    compile 'com.android.support:appcompat-v7:23.0.1'
-    compile 'com.android.support:preference-v7:23.0.1'
-    compile 'com.android.support:support-annotations:23.0.1'
+    implementation 'com.android.support:appcompat-v7:23.0.1'
+    implementation 'com.android.support:preference-v7:23.0.1'
+    implementation 'com.android.support:support-annotations:23.0.1'
 
-    compile 'com.squareup:otto:1.3.8'
+    implementation 'com.squareup:otto:1.3.8'
 
-    compile project(':ijkplayer-java')
-    compile project(':ijkplayer-exo')
+    implementation project(':ijkplayer-java')
+    implementation project(':ijkplayer-exo')
 
-    all32Compile project(':ijkplayer-armv5')
-    all32Compile project(':ijkplayer-armv7a')
-    all32Compile project(':ijkplayer-x86')
+    all32Implementation project(':ijkplayer-armv5')
+    all32Implementation project(':ijkplayer-armv7a')
+    all32Implementation project(':ijkplayer-x86')
 
-    all64Compile project(':ijkplayer-armv5')
-    all64Compile project(':ijkplayer-armv7a')
-    all64Compile project(':ijkplayer-arm64')
-    all64Compile project(':ijkplayer-x86')
-    all64Compile project(':ijkplayer-x86_64')
+    all64Implementation project(':ijkplayer-armv5')
+    all64Implementation project(':ijkplayer-armv7a')
+    all64Implementation project(':ijkplayer-arm64')
+    all64Implementation project(':ijkplayer-x86')
+    all64Implementation project(':ijkplayer-x86_64')
 
-    // compile 'tv.danmaku.ijk.media:ijkplayer-java:0.8.8'
-    // compile 'tv.danmaku.ijk.media:ijkplayer-exo:0.8.8'
+    // implementation 'tv.danmaku.ijk.media:ijkplayer-java:0.8.8'
+    // implementation 'tv.danmaku.ijk.media:ijkplayer-exo:0.8.8'
 
-    // all32Compile 'tv.danmaku.ijk.media:ijkplayer-armv5:0.8.8'
-    // all32Compile 'tv.danmaku.ijk.media:ijkplayer-armv7a:0.8.8'
-    // all32Compile 'tv.danmaku.ijk.media:ijkplayer-x86:0.8.8'
+    // all32Implementation 'tv.danmaku.ijk.media:ijkplayer-armv5:0.8.8'
+    // all32Implementation 'tv.danmaku.ijk.media:ijkplayer-armv7a:0.8.8'
+    // all32Implementation 'tv.danmaku.ijk.media:ijkplayer-x86:0.8.8'
 
-    // all64Compile 'tv.danmaku.ijk.media:ijkplayer-armv5:0.8.8'
-    // all64Compile 'tv.danmaku.ijk.media:ijkplayer-armv7a:0.8.8'
-    // all64Compile 'tv.danmaku.ijk.media:ijkplayer-arm64:0.8.8'
-    // all64Compile 'tv.danmaku.ijk.media:ijkplayer-x86:0.8.8'
-    // all64Compile 'tv.danmaku.ijk.media:ijkplayer-x86_64:0.8.8'
+    // all64Implementation 'tv.danmaku.ijk.media:ijkplayer-armv5:0.8.8'
+    // all64Implementation 'tv.danmaku.ijk.media:ijkplayer-armv7a:0.8.8'
+    // all64Implementation 'tv.danmaku.ijk.media:ijkplayer-arm64:0.8.8'
+    // all64Implementation 'tv.danmaku.ijk.media:ijkplayer-x86:0.8.8'
+    // all64Implementation 'tv.danmaku.ijk.media:ijkplayer-x86_64:0.8.8'
 
-    // armv5Compile project(':player-armv5')
-    // armv7aCompile project(':player-armv7a')
-    // arm64Compile project(':player-arm64')
-    // x86Compile project(':player-x86')
-    // x86_64Compile project(':player-x86_64')
+    // armv5Implementation project(':player-armv5')
+    // armv7aImplementation project(':player-armv7a')
+    // arm64Implementation project(':player-arm64')
+    // x86Implementation project(':player-x86')
+    // x86_64Implementation project(':player-x86_64')
 }

--- a/android/ijkplayer/ijkplayer-example/src/main/res/xml/settings.xml
+++ b/android/ijkplayer/ijkplayer-example/src/main/res/xml/settings.xml
@@ -10,7 +10,7 @@
             android:title="@string/pref_title_enable_background_play" />
         <tv.danmaku.ijk.media.example.widget.preference.IjkListPreference
             android:defaultValue="0"
-            android:entries="@@array/pref_entries_player"
+            android:entries="@array/pref_entries_player"
             android:entryValues="@array/pref_entry_values_player"
             android:key="@string/pref_key_player"
             android:persistent="true"

--- a/android/ijkplayer/ijkplayer-exo/build.gradle
+++ b/android/ijkplayer/ijkplayer-exo/build.gradle
@@ -23,12 +23,10 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
+    implementation 'com.google.android.exoplayer:exoplayer:r1.5.11'
 
-    compile 'com.google.android.exoplayer:exoplayer:r1.5.11'
-
-    compile project(':ijkplayer-java')
-    // compile 'tv.danmaku.ijk.media:ijkplayer-java:0.8.8'
+    implementation project(':ijkplayer-java')
+    // implementation 'tv.danmaku.ijk.media:ijkplayer-java:0.8.8'
 }
 
 gradle.startParameter.taskNames.each { task ->

--- a/android/ijkplayer/ijkplayer-java/build.gradle
+++ b/android/ijkplayer/ijkplayer-java/build.gradle
@@ -22,8 +22,4 @@ android {
     }
 }
 
-dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-}
-
 apply from: new File(rootProject.projectDir, "tools/gradle-on-demand.gradle");

--- a/android/ijkplayer/ijkplayer-x86/build.gradle
+++ b/android/ijkplayer/ijkplayer-x86/build.gradle
@@ -23,8 +23,4 @@ android {
     }
 }
 
-dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-}
-
 apply from: new File(rootProject.projectDir, "tools/gradle-on-demand.gradle");

--- a/android/ijkplayer/ijkplayer-x86_64/build.gradle
+++ b/android/ijkplayer/ijkplayer-x86_64/build.gradle
@@ -23,8 +23,4 @@ android {
     }
 }
 
-dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-}
-
 apply from: new File(rootProject.projectDir, "tools/gradle-on-demand.gradle");


### PR DESCRIPTION
The current gradle configuration will cause unnecessary warning messages ('compile' is deprecated and will be removed by end of 2018).