### PR TITLE
增加预缓冲区pre-reading-buffer

### DIFF
--- a/android/ijkplayer/ijkplayer-java/src/main/java/tv/danmaku/ijk/media/player/IjkMediaPlayer.java
+++ b/android/ijkplayer/ijkplayer-java/src/main/java/tv/danmaku/ijk/media/player/IjkMediaPlayer.java
@@ -126,6 +126,7 @@ public final class IjkMediaPlayer extends AbstractMediaPlayer {
     public static final int FFP_PROP_INT64_AUDIO_CACHED_BYTES               = 20008;
     public static final int FFP_PROP_INT64_VIDEO_CACHED_PACKETS             = 20009;
     public static final int FFP_PROP_INT64_AUDIO_CACHED_PACKETS             = 20010;
+	public static final int FFP_PROP_INT64_PRE_READING_BUFFER               = 20016;
     public static final int FFP_PROP_INT64_ASYNC_STATISTIC_BUF_BACKWARDS    = 20201;
     public static final int FFP_PROP_INT64_ASYNC_STATISTIC_BUF_FORWARDS     = 20202;
     public static final int FFP_PROP_INT64_ASYNC_STATISTIC_BUF_CAPACITY     = 20203;
@@ -492,6 +493,11 @@ public final class IjkMediaPlayer extends AbstractMediaPlayer {
             throws IllegalArgumentException, SecurityException, IllegalStateException {
         _setAndroidIOCallback(androidIO);
     }
+	
+	public void setPreReadingBuffer(long bufferSize) {
+        _setPropertyLong(FFP_PROP_INT64_PRE_READING_BUFFER, bufferSize);
+    }
+
 
     private native void _setDataSource(String path, String[] keys, String[] values)
             throws IOException, IllegalArgumentException, SecurityException, IllegalStateException;

--- a/ijkmedia/ijkplayer/android/pipeline/ffpipenode_android_mediacodec_vdec.c
+++ b/ijkmedia/ijkplayer/android/pipeline/ffpipenode_android_mediacodec_vdec.c
@@ -481,6 +481,15 @@ static int feed_input_buffer2(JNIEnv *env, IJKFF_Pipenode *node, int64_t timeUs,
 #endif
         AVPacket pkt;
         do {
+			//pre-reading
+            if (!ffp->is_pre_reading_prepared && !ffp->is_queue_full_happened && !ffp->is->eof) {
+                int queue_nb_packets = d->queue->nb_packets;
+                int pre_reading_buffer = ffp->pre_reading_buffer;
+                if (queue_nb_packets >= pre_reading_buffer) {
+                    ffp->is_pre_reading_prepared = 1;
+                }
+                continue;
+            }
             if (d->queue->nb_packets == 0)
                 SDL_CondSignal(d->empty_queue_cond);
             if (ffp_packet_queue_get_or_buffering(ffp, d->queue, &pkt, &d->pkt_serial, &d->finished) < 0) {
@@ -726,6 +735,15 @@ static int feed_input_buffer(JNIEnv *env, IJKFF_Pipenode *node, int64_t timeUs, 
 #endif
         AVPacket pkt;
         do {
+			//pre-reading
+            if (!ffp->is_pre_reading_prepared && !ffp->is_queue_full_happened && !ffp->is->eof) {
+                int queue_nb_packets = d->queue->nb_packets;
+                int pre_reading_buffer = ffp->pre_reading_buffer;
+                if (queue_nb_packets >= pre_reading_buffer) {
+                    ffp->is_pre_reading_prepared = 1;
+                }
+                continue;
+            }
             if (d->queue->nb_packets == 0)
                 SDL_CondSignal(d->empty_queue_cond);
             if (ffp_packet_queue_get_or_buffering(ffp, d->queue, &pkt, &d->pkt_serial, &d->finished) < 0) {

--- a/ijkmedia/ijkplayer/ff_ffmsg.h
+++ b/ijkmedia/ijkplayer/ff_ffmsg.h
@@ -82,6 +82,7 @@
 #define FFP_PROP_INT64_AUDIO_CACHED_BYTES               20008
 #define FFP_PROP_INT64_VIDEO_CACHED_PACKETS             20009
 #define FFP_PROP_INT64_AUDIO_CACHED_PACKETS             20010
+#define FFP_PROP_INT64_PRE_READING_BUFFER               20016
 
 #define FFP_PROP_INT64_BIT_RATE                         20100
 

--- a/ijkmedia/ijkplayer/ff_ffplay_def.h
+++ b/ijkmedia/ijkplayer/ff_ffplay_def.h
@@ -720,6 +720,10 @@ typedef struct FFPlayer {
     char *mediacodec_default_name;
     int ijkmeta_delay_init;
     int render_wait_start;
+	/* pre-reading-buffer */
+	int pre_reading_buffer;
+    int is_pre_reading_prepared;
+    int is_queue_full_happened;	
 } FFPlayer;
 
 #define fftime_to_milliseconds(ts) (av_rescale(ts, 1000, AV_TIME_BASE))
@@ -843,6 +847,10 @@ inline static void ffp_reset_internal(FFPlayer *ffp)
     ffp->pf_playback_rate_changed       = 0;
     ffp->pf_playback_volume             = 1.0f;
     ffp->pf_playback_volume_changed     = 0;
+	/* pre-reading-buffer */
+    ffp->pre_reading_buffer             = 0;
+    ffp->is_pre_reading_prepared        = 0;
+    ffp->is_queue_full_happened         = 0;
 
     av_application_closep(&ffp->app_ctx);
     ijkio_manager_destroyp(&ffp->ijkio_manager_ctx);

--- a/ijkmedia/ijkplayer/ff_ffplay_options.h
+++ b/ijkmedia/ijkplayer/ff_ffplay_options.h
@@ -164,6 +164,8 @@ static const AVOption ffp_context_options[] = {
         OPTION_OFFSET(async_init_decoder),   OPTION_INT(0, 0, 1) },
     { "video-mime-type",                    "default video mime type",
         OPTION_OFFSET(video_mime_type),     OPTION_STR(NULL) },
+    { "pre_reading_buffer",                      "pre_reading_buffer_size",
+      OPTION_OFFSET(pre_reading_buffer),       OPTION_INT(0, 0, INT_MAX) },		
 
         // iOS only options
     { "videotoolbox",                       "VideoToolbox: enable",


### PR DESCRIPTION
Ijkplayer中目前还不支持预缓冲（至少达到一定阈值的数据才进行播放 ）
刚开始播放视频，只要有AvPacket数据就立即decode，因为没有预缓冲区的限制，刚启动时AvPacket get的速度有机会等于大于put速度，这导致前1s内容易出现buffering start
因此，我们加了预缓冲区来缓解这个问题（也参考了其他的主流方案）
方案如下：
1、预缓冲区的大小是AvPacket个数为单位，达到阈值后，才会进行解码
2、预缓冲时机在onPrepared之后


