### PR TITLE
ijksdl/Android: Fix bug of green screen when yv12 output

### DIFF
--- a/ijkmedia/ijksdl/android/android_nativewindow.c
+++ b/ijkmedia/ijksdl/android/android_nativewindow.c
@@ -239,6 +239,11 @@ int SDL_Android_NativeWindow_display_l(ANativeWindow *native_window, SDL_VoutOve
             return retval;
         }
 
+        if (NULL != voutDesc) {
+            curr_format = ANativeWindow_getFormat(native_window);
+            voutDesc = native_window_get_desc(curr_format);
+        }
+
         if (!voutDesc) {
             ALOGE("SDL_Android_NativeWindow_display_l: unknown hal format %d", curr_format);
             return -1;


### PR DESCRIPTION
ijksdl/Android:
Fix bug for green screen when yv12 output:
1、I find that, the native window default format is not yuv
2、If I use the yv12 render, the first frame will change the native window format
3、After the change, we need get the voutDesc or the first frame will not be render
4、The system may clear the buffer with zero, but zero for uv is green

        if (NULL != voutDesc) {   //thie means is the format changed
            curr_format = ANativeWindow_getFormat(native_window); //get the new curr_format
            voutDesc = native_window_get_desc(curr_format);//get the new voutDesc
        }
     
Thanks!!!