### PR TITLE
ijkplayer-ios:  support for soft and hard decoding of video rotation

### DIFF
--- a/ios/IJKMediaPlayer/IJKMediaPlayer/IJKFFMoviePlayerController.m
+++ b/ios/IJKMediaPlayer/IJKMediaPlayer/IJKFFMoviePlayerController.m
@@ -59,6 +59,9 @@ static const char *kIJKFFRequiredFFmpegVersion = "ff3.4--ijk0.8.7--20180103--001
     NSInteger _sampleAspectRatioNumerator;
     NSInteger _sampleAspectRatioDenominator;
 
+    int _degrees;
+    BOOL _isRotated;
+    
     BOOL      _seeking;
     NSInteger _bufferingTime;
     NSInteger _bufferingPosition;
@@ -89,6 +92,7 @@ static const char *kIJKFFRequiredFFmpegVersion = "ff3.4--ijk0.8.7--20180103--001
 @synthesize loadState = _loadState;
 
 @synthesize naturalSize = _naturalSize;
+@synthesize rotateDegrees = _rotateDegrees;
 @synthesize scalingMode = _scalingMode;
 @synthesize shouldAutoplay = _shouldAutoplay;
 
@@ -707,6 +711,13 @@ inline static int getPlayerOption(IJKFFOptionCategory category)
 
 - (void)changeNaturalSize
 {
+    if (_isRotated && (_degrees==90 || _degrees==270)) {
+        NSInteger newWidth = _videoHeight;
+        _videoHeight = _videoWidth;
+        _videoWidth = newWidth;
+        NSLog(@"video rotated, new size: %d,%d",(int)_videoWidth,(int)_videoHeight);
+    }
+    
     [self willChangeValueForKey:@"naturalSize"];
     if (_sampleAspectRatioNumerator > 0 && _sampleAspectRatioDenominator > 0) {
         self->_naturalSize = CGSizeMake(1.0f * _videoWidth * _sampleAspectRatioNumerator / _sampleAspectRatioDenominator, _videoHeight);
@@ -720,6 +731,40 @@ inline static int getPlayerOption(IJKFFOptionCategory category)
          postNotificationName:IJKMPMovieNaturalSizeAvailableNotification
          object:self];
     }
+}
+
+- (void)changeRotateInfo {
+    switch (_degrees) {
+        case 90: {
+            _rotateDegrees = IJKMPMovieRotateDegrees_90;
+            CGRect originFrame = self.view.frame;
+            CGAffineTransform transform = CGAffineTransformMakeRotation(M_PI_2);
+            [_view setTransform:transform];
+            [_view setFrame:originFrame];
+            [self changeNaturalSize];
+        } break;
+        case 180: {
+            _rotateDegrees = IJKMPMovieRotateDegrees_180;
+            CGAffineTransform transform = CGAffineTransformMakeRotation(M_PI);
+            [self.view setTransform:transform];
+        } break;
+        case 270: {
+            _rotateDegrees = IJKMPMovieRotateDegrees_270;
+            CGRect originFrame = self.view.frame;
+            CGAffineTransform transform = CGAffineTransformMakeRotation(M_PI_2*3);
+            [self.view setTransform:transform];
+            [self.view setFrame:originFrame];
+            [self changeNaturalSize];
+        } break;
+        default:
+            _rotateDegrees = IJKMPMovieRotateDegrees_0;
+            break;
+    }
+    [[NSNotificationCenter defaultCenter]
+     postNotificationName:IJKMPMovieRotateAvailableNotification
+     object:self
+     userInfo:@{IJKMPMovieRotateAvailableNotificationDegreesUserInfoKey:
+                    @(_rotateDegrees)}];
 }
 
 - (void)setScalingMode: (IJKMPMovieScalingMode) aScalingMode
@@ -1176,6 +1221,14 @@ inline static void fillMetaInternal(NSMutableDictionary *meta, IjkMediaMeta *raw
             if (avmsg->arg2 > 0)
                 _sampleAspectRatioDenominator = avmsg->arg2;
             [self changeNaturalSize];
+            break;
+        case FFP_MSG_VIDEO_ROTATION_CHANGED:
+            _degrees = avmsg->arg1;
+            if (_degrees != 0) {
+                NSLog(@"FFP_MSG_VIDEO_ROTATION_CHANGED: %d\n", _degrees);
+                _isRotated = YES;
+                [self changeRotateInfo];
+            }
             break;
         case FFP_MSG_BUFFERING_START: {
             NSLog(@"FFP_MSG_BUFFERING_START:\n");

--- a/ios/IJKMediaPlayer/IJKMediaPlayer/IJKMediaPlayback.h
+++ b/ios/IJKMediaPlayer/IJKMediaPlayer/IJKMediaPlayback.h
@@ -31,6 +31,13 @@ typedef NS_ENUM(NSInteger, IJKMPMovieScalingMode) {
     IJKMPMovieScalingModeFill        // Non-uniform scale. Both render dimensions will exactly match the visible bounds
 };
 
+typedef NS_ENUM(NSInteger, IJKMPMovieRotateDegrees) {
+    IJKMPMovieRotateDegrees_0,      // 0 degree, no rotation
+    IJKMPMovieRotateDegrees_90,     // rotate 90 degrees
+    IJKMPMovieRotateDegrees_180,    // rotate 180 degrees
+    IJKMPMovieRotateDegrees_270     // rotate 270 degrees
+};
+
 typedef NS_ENUM(NSInteger, IJKMPMoviePlaybackState) {
     IJKMPMoviePlaybackStateStopped,
     IJKMPMoviePlaybackStatePlaying,
@@ -91,6 +98,7 @@ typedef NS_ENUM(NSInteger, IJKMPMovieTimeOption) {
 @property(nonatomic, readonly) int64_t numberOfBytesTransferred;
 
 @property(nonatomic, readonly) CGSize naturalSize;
+@property(nonatomic, readonly) IJKMPMovieRotateDegrees rotateDegrees;
 @property(nonatomic) IJKMPMovieScalingMode scalingMode;
 @property(nonatomic) BOOL shouldAutoplay;
 
@@ -144,6 +152,10 @@ IJK_EXTERN NSString* const IJKMPMoviePlayerIsAirPlayVideoActiveDidChangeNotifica
 // Calling -prepareToPlay on the movie player will begin determining movie properties asynchronously.
 // These notifications are posted when the associated movie property becomes available.
 IJK_EXTERN NSString* const IJKMPMovieNaturalSizeAvailableNotification;
+
+// Posted when video rotation property available.
+IJK_EXTERN NSString* const IJKMPMovieRotateAvailableNotification;
+IJK_EXTERN NSString* const IJKMPMovieRotateAvailableNotificationDegreesUserInfoKey; // NSNumber (IJKMPMovieRotateDegrees)
 
 // -----------------------------------------------------------------------------
 //  Extend Notifications

--- a/ios/IJKMediaPlayer/IJKMediaPlayer/IJKMediaPlayback.m
+++ b/ios/IJKMediaPlayer/IJKMediaPlayer/IJKMediaPlayback.m
@@ -35,6 +35,9 @@ NSString *const IJKMPMoviePlayerIsAirPlayVideoActiveDidChangeNotification = @"IJ
 
 NSString *const IJKMPMovieNaturalSizeAvailableNotification = @"IJKMPMovieNaturalSizeAvailableNotification";
 
+NSString *const IJKMPMovieRotateAvailableNotification = @"IJKMPMovieRotateAvailableNotification";
+NSString *const IJKMPMovieRotateAvailableNotificationDegreesUserInfoKey = @"IJKMPMovieRotateAvailableNotificationDegreesUserInfoKey";
+
 NSString *const IJKMPMoviePlayerVideoDecoderOpenNotification = @"IJKMPMoviePlayerVideoDecoderOpenNotification";
 
 NSString *const IJKMPMoviePlayerFirstVideoFrameRenderedNotification = @"IJKMPMoviePlayerFirstVideoFrameRenderedNotification";

--- a/ios/IJKMediaPlayer/IJKMediaPlayer/ijkmedia/ijkplayer/ios/pipeline/ffpipenode_ios_videotoolbox_vdec.m
+++ b/ios/IJKMediaPlayer/IJKMediaPlayer/ijkmedia/ijkplayer/ios/pipeline/ffpipenode_ios_videotoolbox_vdec.m
@@ -47,6 +47,8 @@ int videotoolbox_video_thread(void *arg)
     VideoState *is = ffp->is;
     Decoder   *d = &is->viddec;
     int ret = 0;
+    
+    ffp_notify_msg2(ffp, FFP_MSG_VIDEO_ROTATION_CHANGED, ffp_get_video_rotate_degrees(ffp));
 
     for (;;) {
 


### PR DESCRIPTION
目前没有看到 iOS 上面支持视频旋转，如果开启 AVFilter 后可能出现绿边问题和只能支持软解下的旋转。先通过一个简单的视图旋转实现软硬解码下的视频旋转，如有问题，欢迎指正