### PR TITLE
IJKSDLGLView running warning

### DIFF
--- a/ios/IJKMediaPlayer/IJKMediaPlayer/ijkmedia/ijksdl/ios/IJKSDLGLView.m
+++ b/ios/IJKMediaPlayer/IJKMediaPlayer/ijkmedia/ijksdl/ios/IJKSDLGLView.m
@@ -80,6 +80,7 @@ typedef NS_ENUM(NSInteger, IJKSDLGLViewApplicationState) {
     if (self) {
         _tryLockErrorCount = 0;
         _shouldLockWhileBeingMovedToWindow = YES;
+        _applicationState = IJKSDLGLViewApplicationForegroundState;
         self.glActiveLock = [[NSRecursiveLock alloc] init];
         _registeredNotifications = [[NSMutableArray alloc] init];
         [self registerApplicationObservers];


### PR DESCRIPTION
Reason:“ [UIApplication sharedApplication].applicationState” must be called in the main thread, but the “isApplicationActive” method is called repeatedly in the child thread, which is easy to cause crash.
Solution: Add “_applicationState” to the default state of “IJKSDLGLViewApplicationForegroundState”, so that the system method in the default branch will not be taken.