### PR TITLE
[fix] Demo - 修复具有file schema的Uri播放失败的问题

### DIFF
--- a/android/ijkplayer/ijkplayer-example/src/main/java/tv/danmaku/ijk/media/example/widget/media/IjkVideoView.java
+++ b/android/ijkplayer/ijkplayer-example/src/main/java/tv/danmaku/ijk/media/example/widget/media/IjkVideoView.java
@@ -336,7 +336,7 @@ public class IjkVideoView extends FrameLayout implements MediaController.MediaPl
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M &&
                     mSettings.getUsingMediaDataSource() &&
                     (TextUtils.isEmpty(scheme) || scheme.equalsIgnoreCase("file"))) {
-                IMediaDataSource dataSource = new FileMediaDataSource(new File(mUri.toString()));
+                IMediaDataSource dataSource = new FileMediaDataSource(new File(mUri.getPath()));
                 mMediaPlayer.setDataSource(dataSource);
             }  else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
                 mMediaPlayer.setDataSource(mAppContext, mUri, mHeaders);


### PR DESCRIPTION
如果mUri是个具有File Schema的Uri，例如从Uri.fromFile()得到
那么mUri.toString = "file:///storage/xxxx/xxx.mp4"
但new File()的入参并不能识别带有schema的url，导致文件不存在而播放失败