### PR TITLE
Change: Add basic audio data callback framework to the API

### DIFF
--- a/ijkmedia/ijkplayer/ff_ffplay.c
+++ b/ijkmedia/ijkplayer/ff_ffplay.c
@@ -2544,6 +2544,21 @@ reload:
         is->audio_src.fmt = af->frame->format;
     }
 
+#if NOMIT_AUDIO_DSP_CALLBACK_FN==1
+    /** Digital Signal Processing, multi-channel signal *********************************/
+    /*  Run DSP callback function. In-place processing on playback audio data buffer.   */
+    if( ffp->pAudioDSPCbFn )
+    {
+        unsigned int numSamples = af->frame->nb_samples;
+        unsigned int format = af->frame->format;
+        ffp->pAudioDSPCbFn( (void**) af->frame->extended_data, numSamples,
+                            (void**) af->frame->extended_data, &numSamples,
+                                     af->frame->sample_rate,   af->frame->channels,
+                                     format );
+
+    }
+#endif
+
     if (is->swr_ctx) {
         const uint8_t **in = (const uint8_t **)af->frame->extended_data;
         uint8_t **out = &is->audio_buf1;

--- a/ijkmedia/ijkplayer/ff_ffplay_def.h
+++ b/ijkmedia/ijkplayer/ff_ffplay_def.h
@@ -65,6 +65,7 @@
 #include "ff_ffmsg_queue.h"
 #include "ff_ffpipenode.h"
 #include "ijkmeta.h"
+#include "ijkaudiocallback.h"
 
 #define DEFAULT_HIGH_WATER_MARK_IN_BYTES        (256 * 1024)
 
@@ -630,6 +631,10 @@ typedef struct FFPlayer {
     int64_t audio_callback_time;
 #ifdef FFP_MERGE
     SDL_Surface *screen;
+#endif
+
+#if NOMIT_AUDIO_DSP_CALLBACK_FN==1
+    AUDIO_DSP_CBFN pAudioDSPCbFn;
 #endif
 
     /* extra fields */

--- a/ijkmedia/ijkplayer/ijkaudiocallback.h
+++ b/ijkmedia/ijkplayer/ijkaudiocallback.h
@@ -1,8 +1,5 @@
 /*
- * ijkplayer_internal.h
- *
- * Copyright (c) 2013 Bilibili
- * Copyright (c) 2013 Zhang Rui <bbcallen@gmail.com>
+ * ijkaudiocallback.h
  *
  * This file is part of ijkPlayer.
  *
@@ -21,36 +18,16 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef IJKPLAYER_ANDROID__IJKPLAYER_INTERNAL_H
-#define IJKPLAYER_ANDROID__IJKPLAYER_INTERNAL_H
+#ifndef IJKPLAYER__IJKAUDIOCALLBACK_H
+#define IJKPLAYER__IJKAUDIOCALLBACK_H
 
-#include <assert.h>
-#include "ijksdl/ijksdl.h"
-#include "ff_fferror.h"
-#include "ff_ffplay.h"
-#include "ijkplayer.h"
+/* Include support for DSP callback function in library build */
+#define NOMIT_AUDIO_DSP_CALLBACK_FN (0)
 
-struct IjkMediaPlayer {
-    volatile int ref_count;
-    pthread_mutex_t mutex;
-    FFPlayer *ffplayer;
+/* Callback function prototype */
+typedef int (*AUDIO_DSP_CBFN) ( void **inData,           unsigned int  numInSamples,
+                                void **outData,          unsigned int *numOutSamples,
+                                unsigned int sampleRate, unsigned int  numChans,
+                                unsigned int format);
 
-    int (*msg_loop)(void*);
-    SDL_Thread *msg_thread;
-    SDL_Thread _msg_thread;
-
-    int mp_state;
-    char *data_source;
-    void *weak_thiz;
-
-    int restart;
-    int restart_from_beginning;
-    int seek_req;
-    long seek_msec;
-
-#if NOMIT_AUDIO_DSP_CALLBACK_FN==1
-    AUDIO_DSP_CBFN pAudioDSPCbFn;
-#endif
-};
-
-#endif
+#endif//IJKPLAYER__IJKAUDIOCALLBACK_H

--- a/ijkmedia/ijkplayer/ijkplayer.c
+++ b/ijkmedia/ijkplayer/ijkplayer.c
@@ -383,6 +383,14 @@ static int ijkmp_msg_loop(void *arg)
     return ret;
 }
 
+void ijkmp_setAudioDSPCallbackFn( IjkMediaPlayer *mp, AUDIO_DSP_CBFN audioCbFn )
+{
+#if NOMIT_AUDIO_DSP_CALLBACK_FN==1
+    mp->pAudioDSPCbFn = audioCbFn;
+    mp->ffplayer->pAudioDSPCbFn = audioCbFn;
+#endif
+}
+
 static int ijkmp_prepare_async_l(IjkMediaPlayer *mp)
 {
     assert(mp);

--- a/ijkmedia/ijkplayer/ijkplayer.h
+++ b/ijkmedia/ijkplayer/ijkplayer.h
@@ -28,6 +28,7 @@
 #include "ff_ffmsg_queue.h"
 
 #include "ijkmeta.h"
+#include "ijkaudiocallback.h"
 
 #ifndef MPTRACE
 #define MPTRACE ALOGD
@@ -197,6 +198,7 @@ void            ijkmp_dec_ref(IjkMediaPlayer *mp);
 void            ijkmp_dec_ref_p(IjkMediaPlayer **pmp);
 
 int             ijkmp_set_data_source(IjkMediaPlayer *mp, const char *url);
+void            ijkmp_setAudioDSPCallbackFn( IjkMediaPlayer *mp, AUDIO_DSP_CBFN audioCbFn );
 int             ijkmp_prepare_async(IjkMediaPlayer *mp);
 int             ijkmp_start(IjkMediaPlayer *mp);
 int             ijkmp_pause(IjkMediaPlayer *mp);

--- a/ios/IJKMediaPlayer/IJKMediaPlayer.xcodeproj/project.pbxproj
+++ b/ios/IJKMediaPlayer/IJKMediaPlayer.xcodeproj/project.pbxproj
@@ -271,6 +271,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		3CA61AE3230E25EF003CCA37 /* ijkaudiocallback.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ijkaudiocallback.h; sourceTree = "<group>"; };
 		454316201A66493700676070 /* ffpipeline_ios.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = ffpipeline_ios.c; path = ijkmedia/ijkplayer/ios/pipeline/ffpipeline_ios.c; sourceTree = "<group>"; };
 		454316211A66493700676070 /* ffpipeline_ios.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ffpipeline_ios.h; path = ijkmedia/ijkplayer/ios/pipeline/ffpipeline_ios.h; sourceTree = "<group>"; };
 		454316221A66493700676070 /* ffpipenode_ios_videotoolbox_vdec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ffpipenode_ios_videotoolbox_vdec.h; path = ijkmedia/ijkplayer/ios/pipeline/ffpipenode_ios_videotoolbox_vdec.h; sourceTree = "<group>"; };
@@ -744,6 +745,7 @@
 				E6903FDC17EAFC6100CFD954 /* ff_ffplay.h */,
 				E69BE5491B93FED300AFBA3F /* ijkavformat */,
 				E69BE54E1B93FED300AFBA3F /* ijkavutil */,
+				3CA61AE3230E25EF003CCA37 /* ijkaudiocallback.h */,
 				E6FAD9551A515CE300725002 /* ijkmeta.c */,
 				E6FAD9561A515CE300725002 /* ijkmeta.h */,
 				E66F8DEE17EFEA9400354D80 /* ijkplayer_internal.h */,

--- a/ios/IJKMediaPlayer/IJKMediaPlayer/IJKFFMoviePlayerController.m
+++ b/ios/IJKMediaPlayer/IJKMediaPlayer/IJKFFMoviePlayerController.m
@@ -455,6 +455,14 @@ void IJKFFIOStatCompleteRegister(void (*cb)(const char *url,
     _pauseInBackground = pause;
 }
 
+- (void)setAudioDSPCallbackFn:(AUDIO_DSP_CBFN)pAudioDSPCbFn
+{
+    if (!_mediaPlayer)
+        return;
+
+    ijkmp_setAudioDSPCallbackFn( _mediaPlayer, pAudioDSPCbFn );
+}
+
 - (BOOL)isVideoToolboxOpen
 {
     if (!_mediaPlayer)

--- a/ios/IJKMediaPlayer/IJKMediaPlayer/IJKMediaPlayback.h
+++ b/ios/IJKMediaPlayer/IJKMediaPlayer/IJKMediaPlayback.h
@@ -53,6 +53,12 @@ typedef NS_ENUM(NSInteger, IJKMPMovieFinishReason) {
     IJKMPMovieFinishReasonUserExited
 };
 
+/* Callback function prototype */
+typedef int (*AUDIO_DSP_CBFN) ( void **inData,           unsigned int  numInSamples,
+                                void **outData,          unsigned int *numOutSamples,
+                                unsigned int sampleRate, unsigned int  numChans,
+                                unsigned int format );
+
 // -----------------------------------------------------------------------------
 // Thumbnails
 
@@ -74,6 +80,7 @@ typedef NS_ENUM(NSInteger, IJKMPMovieTimeOption) {
 - (BOOL)isPlaying;
 - (void)shutdown;
 - (void)setPauseInBackground:(BOOL)pause;
+- (void)setAudioDSPCallbackFn:(AUDIO_DSP_CBFN)pAudioDSPCbFn;
 
 @property(nonatomic, readonly)  UIView *view;
 @property(nonatomic)            NSTimeInterval currentPlaybackTime;


### PR DESCRIPTION
In order to allow DSP (digital signal processing) to operate on the
original multi-channel audio stream, allow an optional callback
function to be registered with the player.
The callback function passes the audio data back to the client layer
which can then process the audio as desired.

[This is a simple "bare-bones" update, just to test the feasibility of the change.  I'd appreciate any feedback - whether making this change is ok, and/or whether it should be added in a different way or location in the codebase.]
