### PR TITLE
add github action build with Android

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -1,0 +1,82 @@
+# This is a basic workflow to help you get started with Actions
+
+name: build-android
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    branches: [ action-build-android ]
+  # 触发添加可选  
+  pull_request:
+    branches: [ master ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      - uses: actions/checkout@v2
+      - name: set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+          
+      - name: Setup Android NDK
+        uses: nttld/setup-ndk@v1.0.6
+        id: setup-ndk
+        with:
+          # Exact version to use
+          ndk-version: r12
+          add-to-path: false     
+      - name: setup yasm
+        run: |
+          brew install yasm      
+          
+      - name: bulid ffmpeg   
+        run: |
+          export ANDROID_NDK=${{ steps.setup-ndk.outputs.ndk-path }}
+          # If you prefer less codec/format for smaller binary size (by default)
+          cd config
+          rm module.sh
+          ln -s module-lite.sh module.sh
+          
+          cd ..
+          
+          # clone ffmpeg
+          ./init-android.sh
+          
+          # clone openssl android: https 
+          ./init-android-openssl.sh
+          
+          cd android/contrib
+          sh compile-ffmpeg.sh clean
+          
+          ./compile-ffmpeg.sh clean
+          ./compile-openssl.sh clean  
+           
+           # 支持https support https
+          ./compile-openssl.sh all
+          ./compile-ffmpeg.sh all
+           # ./android/contrib/build/**/output/include/
+           # ./android/contrib/build/**/output/*.so
+         
+          cd ..
+           #  ./ijkplayer/android/ijkplayer/**/src/main/libs/**/*.so
+          ./compile-ijk.sh all
+      - name: Upload a Build Artifact  
+        uses: actions/upload-artifact@v2
+        with:
+          name: ijkplayer-lib
+          path: |
+           # 更加实际情况得到所需要的输出文件,如果只需要ffmpeglib的so 可以选择下面2个
+           # ./android/contrib/build/**/output/include/
+           # ./android/contrib/build/**/output/*.so
+             ./android/ijkplayer


### PR DESCRIPTION
add github action build with Android
添加Action 来构建，这样就其他人使用时就不需要去配置构建环境，也就不需要担心环境配置的问题了

然后简化后操作：
fork -> 修改ffmpeg的配置或者其他配置->push ->然后自动构建输出需要内容->下载构建输出的内容

这个PR不一定要和， 觉得可以创建一个新项目用来专门做ijkplayer相关的构建
demo:[ijkWoker](https://github.com/SheTieJun/Worker/actions/runs/1470226646)

如果合并,用的时候需要根据具体情况进行修改`build-android.yml`
