### PR TITLE
去掉重复format_init方法，代码格式对齐

### DIFF
--- a/ijkmedia/ijkplayer/ff_ffplay.c
+++ b/ijkmedia/ijkplayer/ff_ffplay.c
@@ -4837,38 +4837,50 @@ int ffp_set_stream_selected(FFPlayer *ffp, int stream, int selected)
     VideoState        *is = ffp->is;
     AVFormatContext   *ic = NULL;
     AVCodecParameters *codecpar = NULL;
-    if (!is)
-        return -1;
-    ic = is->ic;
-    if (!ic)
+    int change_stream = 0;
+    if (!is || !is->ic)
         return -1;
 
+    ic = is->ic;
     if (stream < 0 || stream >= ic->nb_streams) {
         av_log(ffp, AV_LOG_ERROR, "invalid stream index %d >= stream number (%d)\n", stream, ic->nb_streams);
         return -1;
     }
 
     codecpar = ic->streams[stream]->codecpar;
+    long current_pos = ffp_get_current_position_l(ffp);
 
     if (selected) {
         switch (codecpar->codec_type) {
             case AVMEDIA_TYPE_VIDEO:
-                if (stream != is->video_stream && is->video_stream >= 0)
+                if (stream != is->video_stream && is->video_stream >= 0) {
                     stream_component_close(ffp, is->video_stream);
+                    change_stream = 1;
+                }
                 break;
             case AVMEDIA_TYPE_AUDIO:
-                if (stream != is->audio_stream && is->audio_stream >= 0)
+                if (stream != is->audio_stream && is->audio_stream >= 0) {
                     stream_component_close(ffp, is->audio_stream);
+                    change_stream = 1;
+                }
                 break;
             case AVMEDIA_TYPE_SUBTITLE:
-                if (stream != is->subtitle_stream && is->subtitle_stream >= 0)
+                if (stream != is->subtitle_stream && is->subtitle_stream >= 0) {
                     stream_component_close(ffp, is->subtitle_stream);
+                    change_stream = 1;
+                }
                 break;
             default:
                 av_log(ffp, AV_LOG_ERROR, "select invalid stream %d of video type %d\n", stream, codecpar->codec_type);
                 return -1;
         }
-        return stream_component_open(ffp, stream);
+        if (change_stream) {
+            int ret = stream_component_open(ffp, stream);
+            ffp_seek_to_l(ffp, current_pos);
+            return ret;
+        } else {
+            return 0;
+        }
     } else {
         switch (codecpar->codec_type) {
             case AVMEDIA_TYPE_VIDEO:

--- a/ios/IJKMediaPlayer/IJKMediaPlayer/ijkmedia/ijkplayer/ios/pipeline/IJKVideoToolBoxAsync.m
+++ b/ios/IJKMediaPlayer/IJKMediaPlayer/ijkmedia/ijkplayer/ios/pipeline/IJKVideoToolBoxAsync.m
@@ -540,6 +540,9 @@ static VTDecompressionSessionRef vtbsession_create(Ijk_VideoToolBox_Opaque* cont
     OSStatus status;
 
     ret = vtbformat_init(&context->fmt_desc, context->codecpar);
+    if (ret) {
+        return NULL;
+    }
 
     if (ffp->vtb_max_frame_width > 0 && width > ffp->vtb_max_frame_width) {
         double w_scaler = (float)ffp->vtb_max_frame_width / width;
@@ -1101,42 +1104,42 @@ static int vtbformat_init(VTBFormatDesc *fmt_desc, AVCodecParameters *codecpar)
         if (level == 0 && sps_level > 0)
             level = sps_level;
 
-                if (profile == 0 && sps_profile > 0)
-                    profile = sps_profile;
-                if (profile == FF_PROFILE_H264_MAIN && level == 32 && fmt_desc->max_ref_frames > 4) {
-                    ALOGE("%s - Main@L3.2 detected, VTB cannot decode with %d ref frames", __FUNCTION__, fmt_desc->max_ref_frames);
-                    goto fail;
-                }
+        if (profile == 0 && sps_profile > 0)
+            profile = sps_profile;
+        if (profile == FF_PROFILE_H264_MAIN && level == 32 && fmt_desc->max_ref_frames > 4) {
+            ALOGE("%s - Main@L3.2 detected, VTB cannot decode with %d ref frames", __FUNCTION__, fmt_desc->max_ref_frames);
+            goto fail;
+        }
 
-                if (extradata[4] == 0xFE) {
-                    extradata[4] = 0xFF;
-                    fmt_desc->convert_3byteTo4byteNALSize = true;
-                }
+        if (extradata[4] == 0xFE) {
+            extradata[4] = 0xFF;
+            fmt_desc->convert_3byteTo4byteNALSize = true;
+        }
 
         fmt_desc->fmt_desc = CreateFormatDescriptionFromCodecData(format_id, width, height, extradata, extrasize,  IJK_VTB_FCC_AVCC);
         if (fmt_desc->fmt_desc == NULL) {
             goto fail;
         }
 
-                ALOGI("%s - using avcC atom of size(%d), ref_frames(%d)", __FUNCTION__, extrasize, fmt_desc->max_ref_frames);
-            } else {
-                if ((extradata[0] == 0 && extradata[1] == 0 && extradata[2] == 0 && extradata[3] == 1) ||
-                    (extradata[0] == 0 && extradata[1] == 0 && extradata[2] == 1)) {
-                    AVIOContext *pb;
-                    if (avio_open_dyn_buf(&pb) < 0) {
-                        goto fail;
-                    }
+        ALOGI("%s - using avcC atom of size(%d), ref_frames(%d)", __FUNCTION__, extrasize, fmt_desc->max_ref_frames);
+    } else {
+        if ((extradata[0] == 0 && extradata[1] == 0 && extradata[2] == 0 && extradata[3] == 1) ||
+            (extradata[0] == 0 && extradata[1] == 0 && extradata[2] == 1)) {
+            AVIOContext *pb;
+            if (avio_open_dyn_buf(&pb) < 0) {
+                goto fail;
+            }
 
-                    fmt_desc->convert_bytestream = true;
-                    ff_isom_write_avcc(pb, extradata, extrasize);
-                    extradata = NULL;
+            fmt_desc->convert_bytestream = true;
+            ff_isom_write_avcc(pb, extradata, extrasize);
+            extradata = NULL;
 
-                    extrasize = avio_close_dyn_buf(pb, &extradata);
+            extrasize = avio_close_dyn_buf(pb, &extradata);
 
-                    if (!validate_avcC_spc(extradata, extrasize, &fmt_desc->max_ref_frames, &sps_level, &sps_profile)) {
-                        av_free(extradata);
-                        goto fail;
-                    }
+            if (!validate_avcC_spc(extradata, extrasize, &fmt_desc->max_ref_frames, &sps_level, &sps_profile)) {
+                av_free(extradata);
+                goto fail;
+            }
 
             fmt_desc->fmt_desc = CreateFormatDescriptionFromCodecData(format_id, width, height, extradata, extrasize, IJK_VTB_FCC_AVCC);
             if (fmt_desc->fmt_desc == NULL) {
@@ -1189,12 +1192,6 @@ Ijk_VideoToolBox_Opaque* videotoolbox_async_create(FFPlayer* ffp, AVCodecContext
 
     context_vtb->ffp = ffp;
     context_vtb->idr_based_identified = true;
-
-    ret = vtbformat_init(&context_vtb->fmt_desc, context_vtb->codecpar);
-    if (ret)
-        goto fail;
-    assert(context_vtb->fmt_desc.fmt_desc);
-    vtbformat_destroy(&context_vtb->fmt_desc);
 
     context_vtb->vt_session = vtbsession_create(context_vtb);
     if (context_vtb->vt_session == NULL)


### PR DESCRIPTION
在videotoolbox_sync_create方法调用vtb_format_init()，
但内部vtbsession_create()又调用vtb_format_init()，去掉其中一个重复调用。
另外，vtb_format_init的代码缩进有一些问题，现改为对齐。