### PR TITLE
修复切换音轨崩溃与音视频不同步问题

### DIFF
--- a/ijkmedia/ijkplayer/ff_ffplay.c
+++ b/ijkmedia/ijkplayer/ff_ffplay.c
@@ -4837,38 +4837,50 @@ int ffp_set_stream_selected(FFPlayer *ffp, int stream, int selected)
     VideoState        *is = ffp->is;
     AVFormatContext   *ic = NULL;
     AVCodecParameters *codecpar = NULL;
-    if (!is)
-        return -1;
-    ic = is->ic;
-    if (!ic)
+    int change_stream = 0;
+    if (!is || !is->ic)
         return -1;
 
+    ic = is->ic;
     if (stream < 0 || stream >= ic->nb_streams) {
         av_log(ffp, AV_LOG_ERROR, "invalid stream index %d >= stream number (%d)\n", stream, ic->nb_streams);
         return -1;
     }
 
     codecpar = ic->streams[stream]->codecpar;
+    long current_pos = ffp_get_current_position_l(ffp);
 
     if (selected) {
         switch (codecpar->codec_type) {
             case AVMEDIA_TYPE_VIDEO:
-                if (stream != is->video_stream && is->video_stream >= 0)
+                if (stream != is->video_stream && is->video_stream >= 0) {
                     stream_component_close(ffp, is->video_stream);
+                    change_stream = 1;
+                }
                 break;
             case AVMEDIA_TYPE_AUDIO:
-                if (stream != is->audio_stream && is->audio_stream >= 0)
+                if (stream != is->audio_stream && is->audio_stream >= 0) {
                     stream_component_close(ffp, is->audio_stream);
+                    change_stream = 1;
+                }
                 break;
             case AVMEDIA_TYPE_SUBTITLE:
-                if (stream != is->subtitle_stream && is->subtitle_stream >= 0)
+                if (stream != is->subtitle_stream && is->subtitle_stream >= 0) {
                     stream_component_close(ffp, is->subtitle_stream);
+                    change_stream = 1;
+                }
                 break;
             default:
                 av_log(ffp, AV_LOG_ERROR, "select invalid stream %d of video type %d\n", stream, codecpar->codec_type);
                 return -1;
         }
-        return stream_component_open(ffp, stream);
+        if (change_stream) {
+            int ret = stream_component_open(ffp, stream);
+            ffp_seek_to_l(ffp, current_pos);
+            return ret;
+        } else {
+            return 0;
+        }
     } else {
         switch (codecpar->codec_type) {
             case AVMEDIA_TYPE_VIDEO:

--- a/ijkmedia/ijkplayer/ijkmeta.c
+++ b/ijkmedia/ijkplayer/ijkmeta.c
@@ -227,6 +227,7 @@ void ijkmeta_set_avformat_context_l(IjkMediaMeta *meta, AVFormatContext *ic)
         if (bitrate > 0) {
             ijkmeta_set_int64_l(stream_meta, IJKM_KEY_BITRATE, bitrate);
         }
+        ijkmeta_set_int64_l(stream_meta, IJKM_KEY_STREAM_INDEX, st->index);
 
         switch (codecpar->codec_type) {
             case AVMEDIA_TYPE_VIDEO: {

--- a/ijkmedia/ijkplayer/ijkmeta.h
+++ b/ijkmedia/ijkplayer/ijkmeta.h
@@ -43,6 +43,7 @@
 #define IJKM_VAL_TYPE__TIMEDTEXT "timedtext"
 #define IJKM_VAL_TYPE__UNKNOWN  "unknown"
 #define IJKM_KEY_LANGUAGE       "language"
+#define IJKM_KEY_STREAM_INDEX   "index"
 
 #define IJKM_KEY_CODEC_NAME         "codec_name"
 #define IJKM_KEY_CODEC_PROFILE      "codec_profile"

--- a/ios/IJKMediaPlayer/IJKMediaPlayer/IJKFFMoviePlayerController.h
+++ b/ios/IJKMediaPlayer/IJKMediaPlayer/IJKFFMoviePlayerController.h
@@ -41,6 +41,8 @@
 #define k_IJKM_KEY_CODEC_NAME      @"codec_name"
 #define k_IJKM_KEY_CODEC_PROFILE   @"codec_profile"
 #define k_IJKM_KEY_CODEC_LONG_NAME @"codec_long_name"
+#define k_IJKM_KEY_LANGUAGE        @"language"
+#define k_IJKM_KEY_STREAM_INDEX    @"index"
 
 // stream: video
 #define k_IJKM_KEY_WIDTH          @"width"

--- a/ios/IJKMediaPlayer/IJKMediaPlayer/IJKFFMoviePlayerController.m
+++ b/ios/IJKMediaPlayer/IJKMediaPlayer/IJKFFMoviePlayerController.m
@@ -1091,6 +1091,7 @@ inline static void fillMetaInternal(NSMutableDictionary *meta, IjkMediaMeta *raw
                             fillMetaInternal(streamMeta, streamRawMeta, IJKM_KEY_CODEC_PROFILE, nil);
                             fillMetaInternal(streamMeta, streamRawMeta, IJKM_KEY_CODEC_LONG_NAME, nil);
                             fillMetaInternal(streamMeta, streamRawMeta, IJKM_KEY_BITRATE, nil);
+                            fillMetaInternal(streamMeta, streamRawMeta, IJKM_KEY_STREAM_INDEX, nil);
 
                             if (0 == strcmp(type, IJKM_VAL_TYPE__VIDEO)) {
                                 fillMetaInternal(streamMeta, streamRawMeta, IJKM_KEY_WIDTH, nil);
@@ -1116,10 +1117,13 @@ inline static void fillMetaInternal(NSMutableDictionary *meta, IjkMediaMeta *raw
                             } else if (0 == strcmp(type, IJKM_VAL_TYPE__AUDIO)) {
                                 fillMetaInternal(streamMeta, streamRawMeta, IJKM_KEY_SAMPLE_RATE, nil);
                                 fillMetaInternal(streamMeta, streamRawMeta, IJKM_KEY_CHANNEL_LAYOUT, nil);
+                                fillMetaInternal(streamMeta, streamRawMeta, IJKM_KEY_LANGUAGE, nil);
 
                                 if (audio_stream == i) {
                                     _monitor.audioMeta = streamMeta;
                                 }
+                            } else if (0 == strcmp(type, IJKM_VAL_TYPE__TIMEDTEXT)) {
+                                fillMetaInternal(streamMeta, streamRawMeta, IJKM_KEY_LANGUAGE, nil);
                             }
                         }
                     }


### PR DESCRIPTION
目前是相同音轨也执行切换，导致后续切换崩溃。
另外，切换音轨后音频时钟没有校正，存在音视频不同步。

关联issue：
#509 
#728 
#1023 
#3811 
#3964 
#4443

处理方案：判断stream id，相同音轨不执行切换；
切换后seek回上一个关键帧，来校正音频时钟，做音视频同步播放。