### PR TITLE
support latest Android Studio Chipmunk 2021.2.1 version.

### DIFF
--- a/android/ijkplayer/build.gradle
+++ b/android/ijkplayer/build.gradle
@@ -2,10 +2,14 @@
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
+        google()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.3'
+        classpath 'com.android.tools.build:gradle:3.2.1'
 
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7'
@@ -16,15 +20,19 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
+        mavenCentral()
+        google()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
 }
 
 ext {
-    compileSdkVersion = 25
-    buildToolsVersion = "25.0.3"
+    compileSdkVersion = 28
+    buildToolsVersion = "28.0.3"
 
-    targetSdkVersion = 25
+    targetSdkVersion = 28
 
     versionCode = 800800
     versionName = "0.8.8"

--- a/android/ijkplayer/gradle/wrapper/gradle-wrapper.properties
+++ b/android/ijkplayer/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Wed Aug 24 16:26:25 CST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.8-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/android/ijkplayer/ijkplayer-arm64/build.gradle
+++ b/android/ijkplayer/ijkplayer-arm64/build.gradle
@@ -24,7 +24,7 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
 }
 
 apply from: new File(rootProject.projectDir, "tools/gradle-on-demand.gradle");

--- a/android/ijkplayer/ijkplayer-armv5/build.gradle
+++ b/android/ijkplayer/ijkplayer-armv5/build.gradle
@@ -24,7 +24,7 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
 }
 
 apply from: new File(rootProject.projectDir, "tools/gradle-on-demand.gradle");

--- a/android/ijkplayer/ijkplayer-armv7a/build.gradle
+++ b/android/ijkplayer/ijkplayer-armv7a/build.gradle
@@ -24,7 +24,7 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
 }
 
 apply from: new File(rootProject.projectDir, "tools/gradle-on-demand.gradle");

--- a/android/ijkplayer/ijkplayer-example/build.gradle
+++ b/android/ijkplayer/ijkplayer-example/build.gradle
@@ -17,12 +17,14 @@ android {
         versionCode rootProject.ext.versionCode
         versionName rootProject.ext.versionName
     }
+
     buildTypes {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    flavorDimensions "version"
     productFlavors {
         all32 { minSdkVersion 9 }
         all64 { minSdkVersion 21 }
@@ -34,25 +36,25 @@ android {
 }
 
 dependencies {
-    compile fileTree(include: ['*.jar'], dir: 'libs')
-    compile 'com.android.support:appcompat-v7:23.0.1'
-    compile 'com.android.support:preference-v7:23.0.1'
-    compile 'com.android.support:support-annotations:23.0.1'
+    implementation fileTree(include: ['*.jar'], dir: 'libs')
+    implementation 'com.android.support:appcompat-v7:23.0.1'
+    implementation 'com.android.support:preference-v7:23.0.1'
+    implementation 'com.android.support:support-annotations:23.0.1'
 
-    compile 'com.squareup:otto:1.3.8'
+    implementation 'com.squareup:otto:1.3.8'
 
-    compile project(':ijkplayer-java')
-    compile project(':ijkplayer-exo')
+    implementation project(':ijkplayer-java')
+    implementation project(':ijkplayer-exo')
 
-    all32Compile project(':ijkplayer-armv5')
-    all32Compile project(':ijkplayer-armv7a')
-    all32Compile project(':ijkplayer-x86')
+    all32Implementation project(':ijkplayer-armv5')
+    all32Implementation project(':ijkplayer-armv7a')
+    all32Implementation project(':ijkplayer-x86')
 
-    all64Compile project(':ijkplayer-armv5')
-    all64Compile project(':ijkplayer-armv7a')
-    all64Compile project(':ijkplayer-arm64')
-    all64Compile project(':ijkplayer-x86')
-    all64Compile project(':ijkplayer-x86_64')
+    all64Implementation project(':ijkplayer-armv5')
+    all64Implementation project(':ijkplayer-armv7a')
+    all64Implementation project(':ijkplayer-arm64')
+    all64Implementation project(':ijkplayer-x86')
+    all64Implementation project(':ijkplayer-x86_64')
 
     // compile 'tv.danmaku.ijk.media:ijkplayer-java:0.8.8'
     // compile 'tv.danmaku.ijk.media:ijkplayer-exo:0.8.8'

--- a/android/ijkplayer/ijkplayer-exo/build.gradle
+++ b/android/ijkplayer/ijkplayer-exo/build.gradle
@@ -23,12 +23,12 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
 
-    compile 'com.google.android.exoplayer:exoplayer:r1.5.11'
+    implementation 'com.google.android.exoplayer:exoplayer:r1.5.11'
 
-    compile project(':ijkplayer-java')
-    // compile 'tv.danmaku.ijk.media:ijkplayer-java:0.8.8'
+    implementation project(':ijkplayer-java')
+    // implementation 'tv.danmaku.ijk.media:ijkplayer-java:0.8.8'
 }
 
 gradle.startParameter.taskNames.each { task ->

--- a/android/ijkplayer/ijkplayer-java/build.gradle
+++ b/android/ijkplayer/ijkplayer-java/build.gradle
@@ -23,7 +23,7 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
 }
 
 apply from: new File(rootProject.projectDir, "tools/gradle-on-demand.gradle");

--- a/android/ijkplayer/ijkplayer-x86/build.gradle
+++ b/android/ijkplayer/ijkplayer-x86/build.gradle
@@ -24,7 +24,7 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
 }
 
 apply from: new File(rootProject.projectDir, "tools/gradle-on-demand.gradle");

--- a/android/ijkplayer/ijkplayer-x86_64/build.gradle
+++ b/android/ijkplayer/ijkplayer-x86_64/build.gradle
@@ -24,7 +24,7 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
 }
 
 apply from: new File(rootProject.projectDir, "tools/gradle-on-demand.gradle");


### PR DESCRIPTION
1. Update gradle plugin version to 3.2.1
2. Update gradle wrapper version to 4.8
3. Remove jcenter repositories
4. Add google and maven repositories