### PR TITLE
解决m系列mac编译异常的问题

### DIFF
--- a/android/compile-ijk.sh
+++ b/android/compile-ijk.sh
@@ -54,17 +54,17 @@ do_sub_cmd () {
 
     case $SUB_CMD in
         prof)
-            $ANDROID_NDK/ndk-build $FF_MAKEFLAGS
+            arch -x86_64 $ANDROID_NDK/ndk-build $FF_MAKEFLAGS
         ;;
         clean)
-            $ANDROID_NDK/ndk-build clean
+            arch -x86_64 $ANDROID_NDK/ndk-build clean
         ;;
         rebuild)
-            $ANDROID_NDK/ndk-build clean
-            $ANDROID_NDK/ndk-build $FF_MAKEFLAGS
+            arch -x86_64 $ANDROID_NDK/ndk-build clean
+            arch -x86_64 $ANDROID_NDK/ndk-build $FF_MAKEFLAGS
         ;;
         *)
-            $ANDROID_NDK/ndk-build $FF_MAKEFLAGS
+            arch -x86_64 $ANDROID_NDK/ndk-build $FF_MAKEFLAGS
         ;;
     esac
 }


### PR DESCRIPTION
m1和m2系列的电脑在执行./compile-ijk.sh all脚本的时候，会出现芯片不兼容的问题，改成兼容命令